### PR TITLE
fix: use default values from settings_ui.json when config is empty

### DIFF
--- a/FloatWebPlayer/Plugins/OverlayApi.cs
+++ b/FloatWebPlayer/Plugins/OverlayApi.cs
@@ -443,19 +443,19 @@ namespace FloatWebPlayer.Plugins
                 if (_overlay == null)
                 {
                     // 从配置读取初始位置和大小
+                    // 使用 overlay.size 保持与 settings_ui.json 和 main.js 的一致性
                     var x = _configApi.Get("overlay.x", 50);
                     var y = _configApi.Get("overlay.y", 50);
-                    var width = _configApi.Get("overlay.width", 200);
-                    var height = _configApi.Get("overlay.height", 200);
+                    var size = _configApi.Get("overlay.size", 200);
 
-                    Services.LogService.Instance.Debug("OverlayApi", $"EnsureOverlay: Creating overlay at ({x}, {y}) size ({width}, {height})");
+                    Services.LogService.Instance.Debug("OverlayApi", $"EnsureOverlay: Creating overlay at ({x}, {y}) size ({size})");
 
                     var options = new OverlayOptions
                     {
                         X = Convert.ToDouble(x),
                         Y = Convert.ToDouble(y),
-                        Width = Convert.ToDouble(width),
-                        Height = Convert.ToDouble(height)
+                        Width = Convert.ToDouble(size),
+                        Height = Convert.ToDouble(size)
                     };
 
                     _overlay = OverlayManager.Instance.CreateOverlay(_context.PluginId, options);
@@ -489,8 +489,9 @@ namespace FloatWebPlayer.Plugins
             var rect = _overlay.GetRect();
             _configApi.Set("overlay.x", (int)rect.X);
             _configApi.Set("overlay.y", (int)rect.Y);
-            _configApi.Set("overlay.width", (int)rect.Width);
-            _configApi.Set("overlay.height", (int)rect.Height);
+            // 使用 overlay.size 保持与 settings_ui.json 和 main.js 的一致性
+            // 覆盖层为正方形，使用 Width 作为 size
+            _configApi.Set("overlay.size", (int)rect.Width);
         }
 
         /// <summary>

--- a/FloatWebPlayer/Views/OverlayWindow.xaml.cs
+++ b/FloatWebPlayer/Views/OverlayWindow.xaml.cs
@@ -1044,6 +1044,9 @@ namespace FloatWebPlayer.Views
             double newWidth = _resizeStartRect.Width;
             double newHeight = _resizeStartRect.Height;
 
+            // 检测 Shift 键是否按下（正方形约束）
+            bool constrainSquare = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
+
             // 根据方向调整
             switch (_resizeDirection)
             {
@@ -1052,34 +1055,99 @@ namespace FloatWebPlayer.Views
                     newTop = _resizeStartRect.Top + delta.Y;
                     newWidth = _resizeStartRect.Width - delta.X;
                     newHeight = _resizeStartRect.Height - delta.Y;
+                    if (constrainSquare)
+                    {
+                        var maxDelta = Math.Max(Math.Abs(delta.X), Math.Abs(delta.Y));
+                        var signX = delta.X >= 0 ? 1 : -1;
+                        var signY = delta.Y >= 0 ? 1 : -1;
+                        // 使用较大的变化量，保持符号一致
+                        var uniformDelta = maxDelta * (Math.Abs(delta.X) >= Math.Abs(delta.Y) ? signX : signY);
+                        newLeft = _resizeStartRect.Left + uniformDelta;
+                        newTop = _resizeStartRect.Top + uniformDelta;
+                        newWidth = _resizeStartRect.Width - uniformDelta;
+                        newHeight = newWidth;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.TopRight:
                     newTop = _resizeStartRect.Top + delta.Y;
                     newWidth = _resizeStartRect.Width + delta.X;
                     newHeight = _resizeStartRect.Height - delta.Y;
+                    if (constrainSquare)
+                    {
+                        var maxDelta = Math.Max(Math.Abs(delta.X), Math.Abs(delta.Y));
+                        // 右上角：X 增加时宽度增加，Y 减少时高度增加
+                        var sign = Math.Abs(delta.X) >= Math.Abs(delta.Y) 
+                            ? (delta.X >= 0 ? 1 : -1) 
+                            : (delta.Y >= 0 ? -1 : 1);
+                        newWidth = _resizeStartRect.Width + maxDelta * sign;
+                        newHeight = newWidth;
+                        newTop = _resizeStartRect.Top + _resizeStartRect.Height - newHeight;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.BottomLeft:
                     newLeft = _resizeStartRect.Left + delta.X;
                     newWidth = _resizeStartRect.Width - delta.X;
                     newHeight = _resizeStartRect.Height + delta.Y;
+                    if (constrainSquare)
+                    {
+                        var maxDelta = Math.Max(Math.Abs(delta.X), Math.Abs(delta.Y));
+                        // 左下角：X 减少时宽度增加，Y 增加时高度增加
+                        var sign = Math.Abs(delta.X) >= Math.Abs(delta.Y) 
+                            ? (delta.X >= 0 ? -1 : 1) 
+                            : (delta.Y >= 0 ? 1 : -1);
+                        newWidth = _resizeStartRect.Width + maxDelta * sign;
+                        newHeight = newWidth;
+                        newLeft = _resizeStartRect.Left + _resizeStartRect.Width - newWidth;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.BottomRight:
                     newWidth = _resizeStartRect.Width + delta.X;
                     newHeight = _resizeStartRect.Height + delta.Y;
+                    if (constrainSquare)
+                    {
+                        var maxDelta = Math.Max(Math.Abs(delta.X), Math.Abs(delta.Y));
+                        var sign = Math.Abs(delta.X) >= Math.Abs(delta.Y) 
+                            ? (delta.X >= 0 ? 1 : -1) 
+                            : (delta.Y >= 0 ? 1 : -1);
+                        newWidth = _resizeStartRect.Width + maxDelta * sign;
+                        newHeight = newWidth;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.Top:
                     newTop = _resizeStartRect.Top + delta.Y;
                     newHeight = _resizeStartRect.Height - delta.Y;
+                    if (constrainSquare)
+                    {
+                        // 边缘控制点：同时调整两个维度
+                        newWidth = newHeight;
+                        // 保持中心对齐
+                        newLeft = _resizeStartRect.Left + (_resizeStartRect.Width - newWidth) / 2;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.Bottom:
                     newHeight = _resizeStartRect.Height + delta.Y;
+                    if (constrainSquare)
+                    {
+                        newWidth = newHeight;
+                        newLeft = _resizeStartRect.Left + (_resizeStartRect.Width - newWidth) / 2;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.Left:
                     newLeft = _resizeStartRect.Left + delta.X;
                     newWidth = _resizeStartRect.Width - delta.X;
+                    if (constrainSquare)
+                    {
+                        newHeight = newWidth;
+                        newTop = _resizeStartRect.Top + (_resizeStartRect.Height - newHeight) / 2;
+                    }
                     break;
                 case Win32Helper.ResizeDirection.Right:
                     newWidth = _resizeStartRect.Width + delta.X;
+                    if (constrainSquare)
+                    {
+                        newHeight = newWidth;
+                        newTop = _resizeStartRect.Top + (_resizeStartRect.Height - newHeight) / 2;
+                    }
                     break;
             }
 


### PR DESCRIPTION


- Add _itemMap dictionary to track SettingsItem objects alongside UI controls
- Store SettingsItem reference when creating each control (TextBox, Toggle, ComboBox, Slider)
- Update RefreshControlValue to accept optional SettingsItem parameter
- Implement fallback logic to use SettingsItem default values when config values are null
- Handle type conversions properly for numeric and boolean default values
- Unify overlay size configuration to use single "overlay.size" key instead of separate width/height
- Ensure consistency between settings_ui.json, main.js, and C# configuration handling
- Improve control initialization to respect schema defaults when user hasn't set values