### PR TITLE
fix: improve window hierarchy and focus handling

### DIFF
--- a/FloatWebPlayer/App.xaml.cs
+++ b/FloatWebPlayer/App.xaml.cs
@@ -159,6 +159,8 @@ namespace FloatWebPlayer
             _controlBarWindow.PluginCenterRequested += (s, e) =>
             {
                 var pluginCenterWindow = new PluginCenterWindow();
+                // 设置 Owner 为 PlayerWindow，确保插件中心显示在 PlayerWindow 之上
+                pluginCenterWindow.Owner = _playerWindow;
                 pluginCenterWindow.ShowDialog();
             };
 
@@ -166,6 +168,8 @@ namespace FloatWebPlayer
             _controlBarWindow.SettingsRequested += (s, e) =>
             {
                 var settingsWindow = new SettingsWindow();
+                // 设置 Owner 为 PlayerWindow，确保设置窗口显示在 PlayerWindow 之上
+                settingsWindow.Owner = _playerWindow;
                 settingsWindow.ShowDialog();
             };
 


### PR DESCRIPTION
- Set Owner property for PluginCenterWindow and SettingsWindow to ensure correct z-order display
- Add Topmost=true to AnimatedWindow base class to keep management windows above other applications
- Refactor window close logic with new ActivateOwnerAndClose method to properly restore focus to parent window
- Update PluginSettingsWindow.ShowSettings to set Owner instead of manual positioning for consistent window management
- Remove unnecessary Activate() call in RestoreParentModalWindows to prevent focus conflicts
- Add comprehensive comments explaining window hierarchy and focus management strategy These changes ensure proper window layering, prevent focus stealing between Topmost windows, and maintain correct focus restoration when closing child windows.