### PR TITLE
fix: 允许窗口初始位置贴到任务栏底部

### DIFF
--- a/FloatWebPlayer/Services/WindowStateService.cs
+++ b/FloatWebPlayer/Services/WindowStateService.cs
@@ -121,6 +121,8 @@ namespace FloatWebPlayer.Services
         {
             // 获取主屏幕工作区域
             var workArea = System.Windows.SystemParameters.WorkArea;
+            // 获取主屏幕完整高度（包含任务栏）
+            double screenHeight = System.Windows.SystemParameters.PrimaryScreenHeight;
 
             // 计算默认大小：宽度为屏幕的 1/4，高度按 16:9 比例计算
             double defaultWidth = Math.Max(workArea.Width / 4, AppConstants.MinWindowWidth);
@@ -135,7 +137,7 @@ namespace FloatWebPlayer.Services
             return new WindowState
             {
                 Left = workArea.Left,
-                Top = workArea.Bottom - defaultHeight,
+                Top = screenHeight - defaultHeight,  // 贴到屏幕最底部（任务栏底部）
                 Width = defaultWidth,
                 Height = defaultHeight,
                 Opacity = AppConstants.MaxOpacity,

--- a/FloatWebPlayer/Views/PlayerWindow.xaml.cs
+++ b/FloatWebPlayer/Views/PlayerWindow.xaml.cs
@@ -150,12 +150,13 @@ namespace FloatWebPlayer.Views
             Width = Math.Max(state.Width, AppConstants.MinWindowWidth);
             Height = Math.Max(state.Height, AppConstants.MinWindowHeight);
             
-            // 确保窗口在屏幕范围内
+            // 确保窗口在屏幕范围内（允许延伸到任务栏区域）
             var workArea = SystemParameters.WorkArea;
+            double screenHeight = SystemParameters.PrimaryScreenHeight;
             if (Left < workArea.Left) Left = workArea.Left;
             if (Top < workArea.Top) Top = workArea.Top;
             if (Left + Width > workArea.Right) Left = workArea.Right - Width;
-            if (Top + Height > workArea.Bottom) Top = workArea.Bottom - Height;
+            if (Top + Height > screenHeight) Top = screenHeight - Height;  // 使用屏幕高度而非工作区
         }
 
         /// <summary>
@@ -421,7 +422,7 @@ namespace FloatWebPlayer.Views
         /// <summary>
         /// 切换最大化/还原
         /// </summary>
-        private void ToggleMaximize()
+        public void ToggleMaximize()
         {
             if (!_isMaximized)
             {
@@ -446,6 +447,11 @@ namespace FloatWebPlayer.Views
         #endregion
 
         #region Public Properties
+
+        /// <summary>
+        /// 是否处于最大化状态
+        /// </summary>
+        public bool IsMaximized => _isMaximized;
 
         /// <summary>
         /// 是否可以后退


### PR DESCRIPTION
- WindowStateService: 默认位置使用屏幕高度而非工作区高度
- PlayerWindow: 边界检查允许窗口延伸到任务栏区域