### PR TITLE
feat(plugins): add catalog repository client (superseded)

### DIFF
--- a/.github/workflows/update_notice.yml
+++ b/.github/workflows/update_notice.yml
@@ -1,7 +1,10 @@
 name: Update Qiniu Notice
-run-name: "Update notice ${{ github.event.inputs.version }}"
+run-name: "Update notice ${{ github.event.client_payload.version || github.event.inputs.version }}"
 
 on:
+  repository_dispatch:
+    types:
+      - automation_plugin_released
   workflow_dispatch:
     inputs:
       version:
@@ -76,25 +79,72 @@ jobs:
       installer_name: ${{ steps.validate.outputs.installer_name }}
       notes: ${{ steps.validate.outputs.notes }}
       source: ${{ steps.validate.outputs.source }}
+      plugin_only: ${{ steps.validate.outputs.plugin_only }}
+      plugin_version: ${{ steps.validate.outputs.plugin_version }}
+      plugin_min_host_version: ${{ steps.validate.outputs.plugin_min_host_version }}
+      plugin_resource_min_version: ${{ steps.validate.outputs.plugin_resource_min_version }}
+      plugin_package_size: ${{ steps.validate.outputs.plugin_package_size }}
+      plugin_package_sha256: ${{ steps.validate.outputs.plugin_package_sha256 }}
+      plugin_github_url: ${{ steps.validate.outputs.plugin_github_url }}
+      plugin_cnb_url: ${{ steps.validate.outputs.plugin_cnb_url }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Validate inputs
         id: validate
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+          INPUT_MIN_REQUIRED_VERSION: ${{ github.event.inputs.min_required_version }}
+          INPUT_NOTES: ${{ github.event.inputs.notes }}
+          INPUT_SOURCE: ${{ github.event.inputs.source }}
+          INPUT_PLUGIN_VERSION: ${{ github.event.inputs.plugin_version }}
+          INPUT_PLUGIN_MIN_HOST_VERSION: ${{ github.event.inputs.plugin_min_host_version }}
+          INPUT_PLUGIN_RESOURCE_MIN_VERSION: ${{ github.event.inputs.plugin_resource_min_version }}
+          INPUT_PLUGIN_PACKAGE_SIZE: ${{ github.event.inputs.plugin_package_size }}
+          INPUT_PLUGIN_PACKAGE_SHA256: ${{ github.event.inputs.plugin_package_sha256 }}
+          INPUT_PLUGIN_GITHUB_URL: ${{ github.event.inputs.plugin_github_url }}
+          INPUT_PLUGIN_CNB_URL: ${{ github.event.inputs.plugin_cnb_url }}
+          DISPATCH_PLUGIN_VERSION: ${{ github.event.client_payload.version }}
+          DISPATCH_PLUGIN_MIN_HOST_VERSION: ${{ github.event.client_payload.min_host_version }}
+          DISPATCH_PLUGIN_PACKAGE_SIZE: ${{ github.event.client_payload.package_size }}
+          DISPATCH_PLUGIN_PACKAGE_SHA256: ${{ github.event.client_payload.package_sha256 }}
+          DISPATCH_PLUGIN_GITHUB_URL: ${{ github.event.client_payload.github_url }}
+          DISPATCH_PLUGIN_CNB_URL: ${{ github.event.client_payload.cnb_url }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          CHANNEL="${{ github.event.inputs.channel }}"
-          MIN_REQUIRED_VERSION="${{ github.event.inputs.min_required_version }}"
-          NOTES="${{ github.event.inputs.notes }}"
-          SOURCE="${{ github.event.inputs.source }}"
-          PLUGIN_VERSION="${{ github.event.inputs.plugin_version }}"
-          PLUGIN_MIN_HOST_VERSION="${{ github.event.inputs.plugin_min_host_version }}"
-          PLUGIN_RESOURCE_MIN_VERSION="${{ github.event.inputs.plugin_resource_min_version }}"
-          PLUGIN_PACKAGE_SIZE="${{ github.event.inputs.plugin_package_size }}"
-          PLUGIN_PACKAGE_SHA256="${{ github.event.inputs.plugin_package_sha256 }}"
-          PLUGIN_GITHUB_URL="${{ github.event.inputs.plugin_github_url }}"
-          PLUGIN_CNB_URL="${{ github.event.inputs.plugin_cnb_url }}"
+          CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' AkashaNavigator/AkashaNavigator.csproj)
+          PLUGIN_ONLY=false
+
+          if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+            PLUGIN_ONLY=true
+            VERSION="$CSPROJ_VERSION"
+            CHANNEL="stable"
+            MIN_REQUIRED_VERSION="0.0.0"
+            NOTES=""
+            SOURCE="qiniu"
+            PLUGIN_VERSION="$DISPATCH_PLUGIN_VERSION"
+            PLUGIN_MIN_HOST_VERSION="$DISPATCH_PLUGIN_MIN_HOST_VERSION"
+            PLUGIN_RESOURCE_MIN_VERSION=""
+            PLUGIN_PACKAGE_SIZE="$DISPATCH_PLUGIN_PACKAGE_SIZE"
+            PLUGIN_PACKAGE_SHA256="$DISPATCH_PLUGIN_PACKAGE_SHA256"
+            PLUGIN_GITHUB_URL="$DISPATCH_PLUGIN_GITHUB_URL"
+            PLUGIN_CNB_URL="$DISPATCH_PLUGIN_CNB_URL"
+          else
+            VERSION="$INPUT_VERSION"
+            CHANNEL="$INPUT_CHANNEL"
+            MIN_REQUIRED_VERSION="$INPUT_MIN_REQUIRED_VERSION"
+            NOTES="$INPUT_NOTES"
+            SOURCE="$INPUT_SOURCE"
+            PLUGIN_VERSION="$INPUT_PLUGIN_VERSION"
+            PLUGIN_MIN_HOST_VERSION="$INPUT_PLUGIN_MIN_HOST_VERSION"
+            PLUGIN_RESOURCE_MIN_VERSION="$INPUT_PLUGIN_RESOURCE_MIN_VERSION"
+            PLUGIN_PACKAGE_SIZE="$INPUT_PLUGIN_PACKAGE_SIZE"
+            PLUGIN_PACKAGE_SHA256="$INPUT_PLUGIN_PACKAGE_SHA256"
+            PLUGIN_GITHUB_URL="$INPUT_PLUGIN_GITHUB_URL"
+            PLUGIN_CNB_URL="$INPUT_PLUGIN_CNB_URL"
+          fi
 
           # 自动生成安装包文件名
           INSTALLER_NAME="AkashaNavigator.Install.${VERSION}.exe"
@@ -111,14 +161,17 @@ jobs:
             exit 1
           fi
 
-          CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' AkashaNavigator/AkashaNavigator.csproj)
-
           echo "输入版本: $VERSION"
           echo "csproj版本: $CSPROJ_VERSION"
           echo "安装包名称: $INSTALLER_NAME"
 
-          if [[ "$VERSION" != "$CSPROJ_VERSION" ]]; then
+          if [[ "$PLUGIN_ONLY" != "true" && "$VERSION" != "$CSPROJ_VERSION" ]]; then
             echo "❌ 输入版本号与 csproj 中 <Version> 不一致"
+            exit 1
+          fi
+
+          if [[ "$PLUGIN_ONLY" == "true" && -z "$PLUGIN_VERSION" ]]; then
+            echo "❌ 插件发布事件缺少 version"
             exit 1
           fi
 
@@ -149,23 +202,21 @@ jobs:
             fi
           fi
 
-          case "$CHANNEL" in
-            stable|alpha) ;;
-            *)
-              echo "❌ channel 只能是 stable 或 alpha"
-              exit 1
-              ;;
-          esac
+          if [[ "$PLUGIN_ONLY" != "true" ]]; then
+            case "$CHANNEL" in
+              stable|alpha) ;;
+              *)
+                echo "❌ channel 只能是 stable 或 alpha"
+                exit 1
+                ;;
+            esac
 
-          if [[ "$CHANNEL" == "stable" ]]; then
-            if [[ "$VERSION" == *"-"* ]]; then
+            if [[ "$CHANNEL" == "stable" && "$VERSION" == *"-"* ]]; then
               echo "❌ stable 通道不应使用预发布版本号"
               exit 1
             fi
-          fi
 
-          if [[ "$CHANNEL" == "alpha" ]]; then
-            if [[ "$VERSION" != *"-"* ]]; then
+            if [[ "$CHANNEL" == "alpha" && "$VERSION" != *"-"* ]]; then
               echo "⚠️ alpha 通道通常建议使用预发布版本号，例如 1.1.0-alpha.3"
             fi
           fi
@@ -178,6 +229,14 @@ jobs:
           echo "$NOTES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
           echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
+          echo "plugin_only=$PLUGIN_ONLY" >> "$GITHUB_OUTPUT"
+          echo "plugin_version=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "plugin_min_host_version=$PLUGIN_MIN_HOST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "plugin_resource_min_version=$PLUGIN_RESOURCE_MIN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "plugin_package_size=$PLUGIN_PACKAGE_SIZE" >> "$GITHUB_OUTPUT"
+          echo "plugin_package_sha256=$PLUGIN_PACKAGE_SHA256" >> "$GITHUB_OUTPUT"
+          echo "plugin_github_url=$PLUGIN_GITHUB_URL" >> "$GITHUB_OUTPUT"
+          echo "plugin_cnb_url=$PLUGIN_CNB_URL" >> "$GITHUB_OUTPUT"
           echo "✅ 参数校验通过"
 
   build_notice:
@@ -224,13 +283,14 @@ jobs:
           INSTALLER_NAME: ${{ needs.validate.outputs.installer_name }}
           NOTES: ${{ needs.validate.outputs.notes }}
           SOURCE: ${{ needs.validate.outputs.source }}
-          PLUGIN_VERSION: ${{ github.event.inputs.plugin_version }}
-          PLUGIN_MIN_HOST_VERSION: ${{ github.event.inputs.plugin_min_host_version }}
-          PLUGIN_RESOURCE_MIN_VERSION: ${{ github.event.inputs.plugin_resource_min_version }}
-          PLUGIN_PACKAGE_SIZE: ${{ github.event.inputs.plugin_package_size }}
-          PLUGIN_PACKAGE_SHA256: ${{ github.event.inputs.plugin_package_sha256 }}
-          PLUGIN_GITHUB_URL: ${{ github.event.inputs.plugin_github_url }}
-          PLUGIN_CNB_URL: ${{ github.event.inputs.plugin_cnb_url }}
+          PLUGIN_ONLY: ${{ needs.validate.outputs.plugin_only }}
+          PLUGIN_VERSION: ${{ needs.validate.outputs.plugin_version }}
+          PLUGIN_MIN_HOST_VERSION: ${{ needs.validate.outputs.plugin_min_host_version }}
+          PLUGIN_RESOURCE_MIN_VERSION: ${{ needs.validate.outputs.plugin_resource_min_version }}
+          PLUGIN_PACKAGE_SIZE: ${{ needs.validate.outputs.plugin_package_size }}
+          PLUGIN_PACKAGE_SHA256: ${{ needs.validate.outputs.plugin_package_sha256 }}
+          PLUGIN_GITHUB_URL: ${{ needs.validate.outputs.plugin_github_url }}
+          PLUGIN_CNB_URL: ${{ needs.validate.outputs.plugin_cnb_url }}
         run: |
           python - <<'PY'
           import json
@@ -243,19 +303,21 @@ jobs:
           notes = os.environ["NOTES"]
           source = os.environ["SOURCE"]
           plugin_version = os.environ.get("PLUGIN_VERSION", "").strip()
+          plugin_only = os.environ.get("PLUGIN_ONLY", "false") == "true"
 
           with open("out/notice_existing.json", "r", encoding="utf-8") as f:
               data = json.load(f)
               print("✅ 读取现有配置成功")
 
-          # 只更新指定通道
-          data[channel] = {
-              "version": version,
-              "installer": installer_name,
-              "source": source,
-              "notes": notes
-          }
-          data["min_required_version"] = min_required_version
+          if not plugin_only:
+              # 手动发布应用时只更新指定通道。
+              data[channel] = {
+                  "version": version,
+                  "installer": installer_name,
+                  "source": source,
+                  "notes": notes
+              }
+              data["min_required_version"] = min_required_version
 
           if plugin_version:
               plugin_id = "akasha-genshin-automation"
@@ -304,7 +366,8 @@ jobs:
               data["schemaVersion"] = 2
               print(f"✅ 更新远程插件目录: {plugin_id} v{plugin_version}")
 
-          print(f"✅ 更新 {channel} 通道: {version}")
+          if not plugin_only:
+              print(f"✅ 更新 {channel} 通道: {version}")
 
           # 写入压缩格式的 JSON（无缩进、无空格）
           with open("out/notice.json", "w", encoding="utf-8") as f:

--- a/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
+++ b/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
@@ -98,6 +98,19 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public void ConfigureAppServices_RegistersPluginRepositoryServiceAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.ConfigureAppServices();
+
+        var descriptor = services.Single(
+            service => service.ServiceType == typeof(IPluginRepositoryService));
+
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        Assert.Equal(typeof(PluginRepositoryService), descriptor.ImplementationType);
+    }
+
+    [Fact]
     public void ConfigureAppServices_RegistersRemotePluginServicesAsSingletons()
     {
         var services = new ServiceCollection();

--- a/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
+++ b/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
@@ -107,6 +107,8 @@ public class ServiceRegistrationTests
             service => service.ServiceType == typeof(IDownloadSourceSelector));
         var packages = services.Single(
             service => service.ServiceType == typeof(IPluginPackageService));
+        var updates = services.Single(
+            service => service.ServiceType == typeof(IPluginUpdateService));
         var resources = services.Single(
             service => service.ServiceType == typeof(IPluginResourceUpdateService));
 
@@ -114,6 +116,8 @@ public class ServiceRegistrationTests
         Assert.Equal(typeof(DownloadSourceSelector), selector.ImplementationType);
         Assert.Equal(ServiceLifetime.Singleton, packages.Lifetime);
         Assert.Equal(typeof(PluginPackageService), packages.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, updates.Lifetime);
+        Assert.Equal(typeof(PluginUpdateService), updates.ImplementationType);
         Assert.Equal(ServiceLifetime.Singleton, resources.Lifetime);
         Assert.Equal(typeof(PluginResourceUpdateService), resources.ImplementationType);
     }

--- a/AkashaNavigator.Tests/ReleaseWorkflowContractTests.cs
+++ b/AkashaNavigator.Tests/ReleaseWorkflowContractTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace AkashaNavigator.Tests;
+
+public sealed class ReleaseWorkflowContractTests
+{
+    [Fact]
+    public void UpdateNoticeWorkflow_ShouldAcceptAutomationPluginReleaseDispatch()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(GetRepositoryRoot(), ".github", "workflows", "update_notice.yml"));
+
+        Assert.Contains("repository_dispatch:", workflow, StringComparison.Ordinal);
+        Assert.Contains("automation_plugin_released", workflow, StringComparison.Ordinal);
+        Assert.Contains("github.event.client_payload.version", workflow, StringComparison.Ordinal);
+        Assert.Contains("PLUGIN_ONLY", workflow, StringComparison.Ordinal);
+        Assert.Contains("if not plugin_only:", workflow, StringComparison.Ordinal);
+        Assert.Contains("data[\"schemaVersion\"] = 2", workflow, StringComparison.Ordinal);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "AkashaNavigator.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the AkashaNavigator repository root.");
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginRepositoryGitClientTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginRepositoryGitClientTests.cs
@@ -1,0 +1,144 @@
+using System.IO;
+using AkashaNavigator.Services;
+using LibGit2Sharp;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginRepositoryGitClientTests : IDisposable
+{
+    private readonly string _testDirectory =
+        Path.Combine(Path.GetTempPath(), $"akasha-git-client-{Guid.NewGuid():N}");
+
+    [Fact]
+    public async Task SynchronizeAsync_ClonesFetchesAndSkipsUnchangedCheckout()
+    {
+        var sourceDirectory = CreateSourceRepository("first");
+        var cacheDirectory = Path.Combine(_testDirectory, "cache");
+        var client = new PluginRepositoryGitClient();
+
+        var firstCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+        var indexPath = Path.Combine(
+            cacheDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        var firstWriteTime = File.GetLastWriteTimeUtc(indexPath);
+
+        await Task.Delay(20);
+        var unchangedCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+
+        Assert.Equal(firstCommit, unchangedCommit);
+        Assert.Equal(firstWriteTime, File.GetLastWriteTimeUtc(indexPath));
+
+        var secondCommit = CommitIndex(sourceDirectory, "second");
+        var fetchedCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+
+        Assert.Equal(secondCommit, fetchedCommit);
+        Assert.Equal("second", File.ReadAllText(indexPath));
+        Assert.Equal(secondCommit, client.GetHeadCommit(cacheDirectory));
+    }
+
+    [Fact]
+    public async Task SynchronizeAsync_ResetRebuildsCorruptedCache()
+    {
+        var sourceDirectory = CreateSourceRepository("valid");
+        var cacheDirectory = Path.Combine(_testDirectory, "cache");
+        var client = new PluginRepositoryGitClient();
+        await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+        DeleteDirectory(Path.Combine(cacheDirectory, ".git"));
+        File.WriteAllText(
+            Path.Combine(cacheDirectory, AppConstants.PluginRepositoryIndexFileName),
+            "corrupted");
+
+        var commit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: true,
+            CancellationToken.None);
+
+        Assert.Equal("valid", File.ReadAllText(
+            Path.Combine(cacheDirectory, AppConstants.PluginRepositoryIndexFileName)));
+        Assert.Equal(commit, client.GetHeadCommit(cacheDirectory));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            DeleteDirectory(_testDirectory);
+        }
+    }
+
+    private string CreateSourceRepository(string content)
+    {
+        var sourceDirectory = Path.Combine(_testDirectory, "source");
+        Directory.CreateDirectory(sourceDirectory);
+        Repository.Init(sourceDirectory);
+        using var repository = new Repository(sourceDirectory);
+        var indexPath = Path.Combine(
+            sourceDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        File.WriteAllText(indexPath, content);
+        Commands.Stage(repository, AppConstants.PluginRepositoryIndexFileName);
+        repository.Commit("initial", CreateSignature(), CreateSignature());
+        var catalog = repository.CreateBranch(
+            AppConstants.OfficialPluginRepositoryBranch);
+        Commands.Checkout(repository, catalog);
+        return sourceDirectory;
+    }
+
+    private static string CommitIndex(string sourceDirectory, string content)
+    {
+        using var repository = new Repository(sourceDirectory);
+        var indexPath = Path.Combine(
+            sourceDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        File.WriteAllText(indexPath, content);
+        Commands.Stage(repository, AppConstants.PluginRepositoryIndexFileName);
+        return repository.Commit(
+            "update",
+            CreateSignature(),
+            CreateSignature()).Sha;
+    }
+
+    private static Signature CreateSignature()
+    {
+        return new Signature(
+            "Akasha Tests",
+            "tests@example.invalid",
+            DateTimeOffset.UnixEpoch);
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        foreach (var filePath in Directory.EnumerateFiles(
+                     directory,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            File.SetAttributes(filePath, FileAttributes.Normal);
+        }
+
+        Directory.Delete(directory, recursive: true);
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginRepositoryServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginRepositoryServiceTests.cs
@@ -1,0 +1,333 @@
+using System.IO;
+using System.Text.Json;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginRepositoryServiceTests : IDisposable
+{
+    private const string SourceCommit =
+        "0123456789abcdef0123456789abcdef01234567";
+    private const string CatalogCommit =
+        "89abcdef0123456789abcdef0123456789abcdef";
+
+    private readonly string _testDirectory =
+        Path.Combine(Path.GetTempPath(), $"akasha-repository-{Guid.NewGuid():N}");
+    private readonly Mock<ILogService> _logService = new();
+
+    [Fact]
+    public async Task InitializeAsync_UsesValidCacheWithoutSynchronizing()
+    {
+        var repositoryDirectory = GetRepositoryDirectory();
+        WriteIndex(repositoryDirectory, CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.InitializeAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.UsedCache);
+        Assert.Equal(CatalogCommit, result.Value.CatalogCommit);
+        Assert.Equal(0, gitClient.SynchronizeCount);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_SynchronizesAndPublishesFreshSnapshot()
+    {
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, CreateIndex());
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.UsedCache);
+        Assert.Same(result.Value, service.Current);
+        Assert.Equal(AppConstants.OfficialPluginRepositoryGitHubUrl, gitClient.RepositoryUrl);
+        Assert.Equal(AppConstants.OfficialPluginRepositoryBranch, gitClient.Branch);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenSynchronizationFails_ReturnsCachedSnapshot()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit,
+            Synchronize = (_, _, _, _, _) =>
+                Task.FromException<string>(new IOException("network unavailable"))
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.UsedCache);
+        Assert.Equal(CatalogCommit, result.Value.CatalogCommit);
+        _logService.Verify(
+            logger => logger.Warn(
+                nameof(PluginRepositoryService),
+                It.IsAny<string>(),
+                It.IsAny<object?[]>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResetAsync_WhenSynchronizationFails_DoesNotUseCache()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit,
+            Synchronize = (_, _, _, _, _) =>
+                Task.FromException<string>(new IOException("network unavailable"))
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.ResetAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_SYNC_FAILED", result.Error!.Code);
+        Assert.True(gitClient.Reset);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RejectsDuplicateOrUnsortedPluginIds()
+    {
+        var invalidIndex = CreateIndex();
+        invalidIndex.Plugins.Add(CreateEntry("sample-plugin"));
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, invalidIndex);
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_ENTRY_INVALID", result.Error!.Code);
+        Assert.Null(service.Current);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RejectsNullPluginCollectionWithoutThrowing()
+    {
+        var invalidIndex = CreateIndex();
+        invalidIndex.Plugins = null!;
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, invalidIndex);
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_INDEX_INVALID", result.Error!.Code);
+    }
+
+    [Fact]
+    public void SaveSettings_ValidatesAndPersistsRepositorySource()
+    {
+        var service = CreateService(new FakePluginRepositoryGitClient());
+        var invalidResult = service.SaveSettings(
+            new PluginRepositorySettings {
+                SelectedChannel = PluginRepositoryChannel.Custom,
+                CustomUrl = "http://example.com/plugins.git"
+            });
+
+        Assert.True(invalidResult.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_URL_INVALID", invalidResult.Error!.Code);
+
+        var settings = new PluginRepositorySettings {
+            SelectedChannel = PluginRepositoryChannel.Cnb,
+            AutoUpdateRepository = false,
+            AutoUpdateSubscribedPlugins = true
+        };
+        var saveResult = service.SaveSettings(settings);
+
+        Assert.True(saveResult.IsSuccess);
+        var json = File.ReadAllText(GetSettingsFilePath());
+        var persisted = JsonSerializer.Deserialize<PluginRepositorySettings>(
+            json,
+            JsonHelper.ReadOptions);
+        Assert.Equal(PluginRepositoryChannel.Cnb, persisted!.SelectedChannel);
+        Assert.False(persisted.AutoUpdateRepository);
+        Assert.True(persisted.AutoUpdateSubscribedPlugins);
+
+        settings.SelectedChannel = PluginRepositoryChannel.GitHub;
+        var returnedSettings = service.Settings;
+        returnedSettings.SelectedChannel = PluginRepositoryChannel.Custom;
+        Assert.Equal(PluginRepositoryChannel.Cnb, service.Settings.SelectedChannel);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_SerializesConcurrentRepositoryWrites()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var activeCalls = 0;
+        var maximumActiveCalls = 0;
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = async (_, _, _, _, cancellationToken) =>
+        {
+            var active = Interlocked.Increment(ref activeCalls);
+            InterlockedExtensions.Max(ref maximumActiveCalls, active);
+            await Task.Delay(25, cancellationToken);
+            Interlocked.Decrement(ref activeCalls);
+            return CatalogCommit;
+        };
+        var service = CreateService(gitClient);
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(_ => service.RefreshAsync()));
+
+        Assert.All(results, result => Assert.True(result.IsSuccess));
+        Assert.Equal(1, maximumActiveCalls);
+        Assert.Equal(4, gitClient.SynchronizeCount);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    private PluginRepositoryService CreateService(
+        IPluginRepositoryGitClient gitClient)
+    {
+        return new PluginRepositoryService(
+            _logService.Object,
+            gitClient,
+            GetRepositoryDirectory(),
+            GetSettingsFilePath());
+    }
+
+    private string GetRepositoryDirectory()
+    {
+        return Path.Combine(_testDirectory, "repository");
+    }
+
+    private string GetSettingsFilePath()
+    {
+        return Path.Combine(_testDirectory, "plugin-repositories.json");
+    }
+
+    private static PluginRepositoryIndex CreateIndex()
+    {
+        return new PluginRepositoryIndex {
+            SchemaVersion = 1,
+            Commit = SourceCommit,
+            Plugins = new List<PluginRepositoryEntry> {
+                CreateEntry("sample-plugin")
+            }
+        };
+    }
+
+    private static PluginRepositoryEntry CreateEntry(string id)
+    {
+        return new PluginRepositoryEntry {
+            Id = id,
+            Path = $"plugins/{id}",
+            Name = "Sample Plugin",
+            Version = "1.0.0",
+            Description = "Sample description",
+            DistributionType = "repository",
+            MinHostVersion = "1.4.0"
+        };
+    }
+
+    private static void WriteIndex(
+        string repositoryDirectory,
+        PluginRepositoryIndex index)
+    {
+        var result = JsonHelper.SaveToFile(
+            Path.Combine(repositoryDirectory, AppConstants.PluginRepositoryIndexFileName),
+            index);
+        Assert.True(result.IsSuccess);
+    }
+
+    private sealed class FakePluginRepositoryGitClient : IPluginRepositoryGitClient
+    {
+        public Func<string, string, string, bool, CancellationToken, Task<string>>
+            Synchronize { get; set; } =
+                (_, _, _, _, _) => Task.FromResult(CatalogCommit);
+
+        public string? HeadCommit { get; set; }
+
+        public int SynchronizeCount { get; private set; }
+
+        public string? RepositoryUrl { get; private set; }
+
+        public string? Branch { get; private set; }
+
+        public bool Reset { get; private set; }
+
+        public Task<string> SynchronizeAsync(
+            string repositoryUrl,
+            string branch,
+            string repositoryDirectory,
+            bool reset,
+            CancellationToken cancellationToken)
+        {
+            SynchronizeCount++;
+            RepositoryUrl = repositoryUrl;
+            Branch = branch;
+            Reset = reset;
+            return Synchronize(
+                repositoryUrl,
+                branch,
+                repositoryDirectory,
+                reset,
+                cancellationToken);
+        }
+
+        public string? GetHeadCommit(string repositoryDirectory)
+        {
+            return HeadCommit;
+        }
+    }
+
+    private static class InterlockedExtensions
+    {
+        public static void Max(ref int location, int value)
+        {
+            var current = Volatile.Read(ref location);
+            while (current < value)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref location,
+                    value,
+                    current);
+                if (observed == current)
+                {
+                    return;
+                }
+
+                current = observed;
+            }
+        }
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginUpdateServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginUpdateServiceTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.Update;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginUpdateServiceTests
+{
+    private const string PluginId = "akasha-genshin-automation";
+
+    [Fact]
+    public async Task CheckAllUpdatesAsync_WhenRemotePackageIsNewer_ReturnsRemoteUpdate()
+    {
+        var library = CreateLibrary("0.4.2");
+        library.Setup(service => service.CheckAllUpdates()).Returns([]);
+        var packageService = new Mock<IPluginPackageService>();
+        packageService.Setup(service => service.GetRemoteCatalog())
+            .Returns([CreateRemoteCatalogEntry("0.4.3")]);
+        var service = new PluginUpdateService(
+            library.Object,
+            CreateManifestService().Object,
+            packageService.Object);
+
+        var result = await service.CheckAllUpdatesAsync();
+
+        Assert.True(result.IsSuccess);
+        var update = Assert.Single(result.Value!);
+        Assert.Equal(PluginId, update.PluginId);
+        Assert.Equal("0.4.2", update.CurrentVersion);
+        Assert.Equal("0.4.3", update.AvailableVersion);
+        Assert.Equal(PluginUpdateSource.RemotePackage, update.Source);
+    }
+
+    [Fact]
+    public async Task CheckAllUpdatesAsync_WhenBuiltInVersionIsNewer_KeepsBuiltInUpdate()
+    {
+        var library = CreateLibrary("0.4.2");
+        library.Setup(service => service.CheckAllUpdates())
+            .Returns(
+                [
+                    UpdateCheckResult.WithUpdate(
+                        PluginId,
+                        "0.4.2",
+                        "0.4.4",
+                        @"C:\builtin")
+                ]);
+        var packageService = new Mock<IPluginPackageService>();
+        packageService.Setup(service => service.GetRemoteCatalog())
+            .Returns([CreateRemoteCatalogEntry("0.4.3")]);
+        var service = new PluginUpdateService(
+            library.Object,
+            CreateManifestService().Object,
+            packageService.Object);
+
+        var result = await service.CheckAllUpdatesAsync();
+
+        var update = Assert.Single(result.Value!);
+        Assert.Equal("0.4.4", update.AvailableVersion);
+        Assert.Equal(PluginUpdateSource.BuiltIn, update.Source);
+    }
+
+    [Fact]
+    public async Task UpdatePluginAsync_WhenUpdateIsRemote_UsesPackageService()
+    {
+        var library = CreateLibrary("0.4.2");
+        var packageService = new Mock<IPluginPackageService>();
+        packageService.Setup(
+                service => service.InstallOrUpdateAsync(
+                    PluginId,
+                    null,
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo
+                    {
+                        Id = PluginId,
+                        Name = "Akasha 原神自动化",
+                        Version = "0.4.3"
+                    }));
+        var service = new PluginUpdateService(
+            library.Object,
+            CreateManifestService().Object,
+            packageService.Object);
+
+        var result = await service.UpdatePluginAsync(
+            UpdateCheckResult.WithRemoteUpdate(PluginId, "0.4.2", "0.4.3"));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("0.4.2", result.OldVersion);
+        Assert.Equal("0.4.3", result.NewVersion);
+        library.Verify(item => item.UpdatePlugin(It.IsAny<string>()), Times.Never);
+        packageService.Verify(
+            item => item.InstallOrUpdateAsync(
+                PluginId,
+                null,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAllUpdatesAsync_WhenManifestRefreshFails_ReturnsFailure()
+    {
+        var library = CreateLibrary("0.4.2");
+        var manifestService = new Mock<IUpdateManifestService>();
+        manifestService.Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                Result<UpdateManifest>.Failure(
+                    Error.Network("MANIFEST_OFFLINE", "更新清单不可用")));
+        var service = new PluginUpdateService(
+            library.Object,
+            manifestService.Object,
+            Mock.Of<IPluginPackageService>());
+
+        var result = await service.CheckAllUpdatesAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("MANIFEST_OFFLINE", result.Error?.Code);
+        library.Verify(item => item.CheckAllUpdates(), Times.Never);
+    }
+
+    private static Mock<IPluginLibrary> CreateLibrary(string installedVersion)
+    {
+        var installed = new InstalledPluginInfo
+        {
+            Id = PluginId,
+            Name = "Akasha 原神自动化",
+            Version = installedVersion
+        };
+        var library = new Mock<IPluginLibrary>();
+        library.Setup(service => service.GetInstalledPlugins()).Returns([installed]);
+        library.Setup(service => service.GetInstalledPluginInfo(PluginId)).Returns(installed);
+        return library;
+    }
+
+    private static Mock<IUpdateManifestService> CreateManifestService()
+    {
+        var manifest = new UpdateManifest
+        {
+            Stable = new AppUpdateChannelInfo { Version = "1.3.0" }
+        };
+        var service = new Mock<IUpdateManifestService>();
+        service.SetupGet(item => item.Current).Returns(manifest);
+        service.Setup(item => item.RefreshAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<UpdateManifest>.Success(manifest));
+        return service;
+    }
+
+    private static PluginCatalogEntry CreateRemoteCatalogEntry(string version)
+    {
+        return new PluginCatalogEntry
+        {
+            Id = PluginId,
+            Name = "Akasha 原神自动化",
+            Version = version,
+            IsRemote = true,
+            Package = new PluginPackageInfo()
+        };
+    }
+}

--- a/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
@@ -1,0 +1,188 @@
+using System.IO;
+using AkashaNavigator.Core.Events;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Config;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using AkashaNavigator.ViewModels.Pages;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.ViewModels;
+
+public sealed class AvailablePluginsPageViewModelTests
+{
+    private const string CatalogCommit =
+        "89abcdef0123456789abcdef0123456789abcdef";
+
+    [Fact]
+    public void RefreshPluginList_UsesRepositoryIndexAsCatalogAuthority()
+    {
+        var snapshot = CreateSnapshot(usedCache: true);
+        var repositoryService = CreateRepositoryService(snapshot);
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(
+                new List<InstalledPluginInfo> {
+                    new() {
+                        Id = "alpha-plugin",
+                        Name = "Old Alpha",
+                        Version = "1.0.0"
+                    }
+                });
+        var packageService = new Mock<IPluginPackageService>();
+        var viewModel = CreateViewModel(
+            repositoryService.Object,
+            pluginLibrary.Object,
+            packageService.Object);
+
+        viewModel.RefreshPluginList();
+
+        Assert.Equal(2, viewModel.Plugins.Count);
+        var alpha = Assert.Single(
+            viewModel.Plugins.Where(plugin => plugin.Id == "alpha-plugin"));
+        Assert.Equal("2.0.0", alpha.Version);
+        Assert.True(alpha.IsInstalled);
+        Assert.True(alpha.HasUpdate);
+        Assert.Equal(
+            Path.Combine("C:\\catalog-cache", "plugins/alpha-plugin"),
+            alpha.SourceDirectory);
+        packageService.Verify(
+            service => service.GetRemoteCatalog(),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task OnLoadedAsync_ReportsCachedRepositoryAndDoesNotRefreshLegacyManifest()
+    {
+        var snapshot = CreateSnapshot(usedCache: true);
+        var repositoryService = CreateRepositoryService(snapshot);
+        repositoryService
+            .Setup(service => service.InitializeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PluginRepositorySnapshot>.Success(snapshot));
+        var viewModel = CreateViewModel(repositoryService.Object);
+
+        await viewModel.OnLoadedAsync();
+
+        Assert.Contains("本地缓存", viewModel.RepositoryStatusText);
+        Assert.Contains("2 个插件", viewModel.RepositoryStatusText);
+        repositoryService.Verify(
+            service => service.InitializeAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateRepositoryCommand_SavesChannelThenRefreshesCatalog()
+    {
+        var cached = CreateSnapshot(usedCache: true);
+        var fresh = CreateSnapshot(usedCache: false);
+        var current = cached;
+        PluginRepositorySettings? savedSettings = null;
+        var repositoryService = CreateRepositoryService(cached);
+        repositoryService
+            .SetupGet(service => service.Current)
+            .Returns(() => current);
+        repositoryService
+            .Setup(service => service.SaveSettings(
+                It.IsAny<PluginRepositorySettings>()))
+            .Callback<PluginRepositorySettings>(settings => savedSettings = settings)
+            .Returns(Result.Success());
+        repositoryService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => current = fresh)
+            .ReturnsAsync(Result<PluginRepositorySnapshot>.Success(fresh));
+        var viewModel = CreateViewModel(repositoryService.Object);
+        viewModel.SelectedRepositoryChannel = PluginRepositoryChannel.Cnb;
+        viewModel.AutoUpdateRepository = false;
+
+        await viewModel.UpdateRepositoryCommand.ExecuteAsync(null);
+
+        Assert.Equal(PluginRepositoryChannel.Cnb, savedSettings!.SelectedChannel);
+        Assert.False(savedSettings.AutoUpdateRepository);
+        Assert.Contains("最新仓库", viewModel.RepositoryStatusText);
+        repositoryService.Verify(
+            service => service.RefreshAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static AvailablePluginsPageViewModel CreateViewModel(
+        IPluginRepositoryService repositoryService,
+        IPluginLibrary? pluginLibrary = null,
+        IPluginPackageService? packageService = null)
+    {
+        var library = pluginLibrary ?? CreatePluginLibrary().Object;
+        var configService = new Mock<IConfigService>();
+        configService.SetupGet(service => service.Config).Returns(new AppConfig());
+        return new AvailablePluginsPageViewModel(
+            library,
+            Mock.Of<INotificationService>(),
+            Mock.Of<IEventBus>(),
+            repositoryService,
+            packageService ?? Mock.Of<IPluginPackageService>(),
+            configService.Object);
+    }
+
+    private static Mock<IPluginLibrary> CreatePluginLibrary()
+    {
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(new List<InstalledPluginInfo>());
+        return pluginLibrary;
+    }
+
+    private static Mock<IPluginRepositoryService> CreateRepositoryService(
+        PluginRepositorySnapshot snapshot)
+    {
+        var repositoryService = new Mock<IPluginRepositoryService>();
+        repositoryService
+            .SetupGet(service => service.RepositoryDirectory)
+            .Returns("C:\\catalog-cache");
+        repositoryService
+            .SetupGet(service => service.Current)
+            .Returns(snapshot);
+        repositoryService
+            .SetupGet(service => service.Settings)
+            .Returns(new PluginRepositorySettings());
+        repositoryService
+            .Setup(service => service.SaveSettings(
+                It.IsAny<PluginRepositorySettings>()))
+            .Returns(Result.Success());
+        return repositoryService;
+    }
+
+    private static PluginRepositorySnapshot CreateSnapshot(bool usedCache)
+    {
+        return new PluginRepositorySnapshot(
+            new PluginRepositoryIndex {
+                SchemaVersion = 1,
+                Commit = "0123456789abcdef0123456789abcdef01234567",
+                Plugins = new List<PluginRepositoryEntry> {
+                    new() {
+                        Id = "alpha-plugin",
+                        Path = "plugins/alpha-plugin",
+                        Name = "Alpha",
+                        Version = "2.0.0",
+                        Description = "Alpha description",
+                        DistributionType = AppConstants.PluginDistributionRepository,
+                        MinHostVersion = "1.4.0"
+                    },
+                    new() {
+                        Id = "beta-plugin",
+                        Path = "plugins/beta-plugin",
+                        Name = "Beta",
+                        Version = "1.0.0",
+                        Description = "Beta description",
+                        DistributionType = AppConstants.PluginDistributionRelease,
+                        HasBackend = true,
+                        MinHostVersion = "1.4.0"
+                    }
+                }
+            },
+            CatalogCommit,
+            usedCache);
+    }
+}

--- a/AkashaNavigator/AkashaNavigator.csproj
+++ b/AkashaNavigator/AkashaNavigator.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2420.47" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />

--- a/AkashaNavigator/App.xaml.cs
+++ b/AkashaNavigator/App.xaml.cs
@@ -495,12 +495,12 @@ _hotkeyManager = Services.GetRequiredService<HotkeyManager>();
     /// </summary>
     private void SetupPluginUpdateCheck(Views.Windows.PlayerWindow playerWindow)
     {
-        var pluginLibrary = Services.GetRequiredService<IPluginLibrary>();
+        var pluginUpdateService = Services.GetRequiredService<IPluginUpdateService>();
         var profileMarketplaceService = Services.GetRequiredService<ProfileMarketplaceService>();
         var notificationService = Services.GetRequiredService<INotificationService>();
         var eventBus = Services.GetRequiredService<Core.Events.IEventBus>();
 
-        var checker = new PluginUpdateChecker(pluginLibrary, profileMarketplaceService, notificationService, Services,
+        var checker = new PluginUpdateChecker(pluginUpdateService, profileMarketplaceService, notificationService, Services,
                                               eventBus, playerWindow, _config);
         checker.SetupUpdateCheck();
     }

--- a/AkashaNavigator/App.xaml.cs
+++ b/AkashaNavigator/App.xaml.cs
@@ -189,12 +189,42 @@ public partial class App : System.Windows.Application
         var updateManifestService = serviceProvider.GetRequiredService<IUpdateManifestService>();
         var pluginResourceUpdateService =
             serviceProvider.GetRequiredService<IPluginResourceUpdateService>();
+        var pluginRepositoryService =
+            serviceProvider.GetRequiredService<IPluginRepositoryService>();
         var notificationService = serviceProvider.GetRequiredService<INotificationService>();
         _ = RefreshUpdateManifestInBackgroundAsync(
             updateManifestService,
             pluginResourceUpdateService,
             notificationService,
             logService);
+        _ = RefreshPluginRepositoryInBackgroundAsync(
+            pluginRepositoryService,
+            logService);
+    }
+
+    private static async Task RefreshPluginRepositoryInBackgroundAsync(
+        IPluginRepositoryService pluginRepositoryService,
+        ILogService logService)
+    {
+        if (!pluginRepositoryService.Settings.AutoUpdateRepository)
+        {
+            return;
+        }
+
+        var result = await pluginRepositoryService.RefreshAsync();
+        if (result.IsFailure)
+        {
+            logService.Warn(
+                nameof(App),
+                "后台更新插件仓库失败: {ErrorMessage}",
+                result.Error?.Message ?? "未知错误");
+        }
+        else if (result.Value!.UsedCache)
+        {
+            logService.Warn(
+                nameof(App),
+                "后台更新插件仓库失败，继续使用本地缓存");
+        }
     }
 
     private static async Task RefreshUpdateManifestInBackgroundAsync(

--- a/AkashaNavigator/AppConstants.cs
+++ b/AkashaNavigator/AppConstants.cs
@@ -241,6 +241,16 @@ public static class AppConstants
     public const string PluginManifestFileName = "plugin.json";
 
     /// <summary>
+    /// 插件仓库索引文件名。
+    /// </summary>
+    public const string PluginRepositoryIndexFileName = "repo.json";
+
+    /// <summary>
+    /// 插件仓库配置文件名。
+    /// </summary>
+    public const string PluginRepositoriesConfigFileName = "plugin-repositories.json";
+
+    /// <summary>
     /// 插件配置文件名
     /// </summary>
     public const string PluginConfigFileName = "config.json";
@@ -258,6 +268,32 @@ public static class AppConstants
     /// Akasha Automation 插件 ID。
     /// </summary>
     public const string AutomationPluginId = "akasha-genshin-automation";
+
+    /// <summary>
+    /// 官方插件仓库 ID。
+    /// </summary>
+    public const string OfficialPluginRepositoryId = "official";
+
+    /// <summary>
+    /// 官方插件仓库默认分支。
+    /// </summary>
+    public const string OfficialPluginRepositoryBranch = "catalog";
+
+    /// <summary>
+    /// 官方插件仓库 GitHub 地址。
+    /// </summary>
+    public const string OfficialPluginRepositoryGitHubUrl =
+        "https://github.com/ColinXHL/akasha-plugins.git";
+
+    /// <summary>
+    /// 官方插件仓库 CNB 地址。
+    /// </summary>
+    public const string OfficialPluginRepositoryCnbUrl =
+        "https://cnb.cool/AkashaNavigator/akasha-plugins.git";
+
+    public const string PluginDistributionRepository = "repository";
+
+    public const string PluginDistributionRelease = "release";
 
     /// <summary>
     /// Notice 中拾取黑名单资源的键。

--- a/AkashaNavigator/Core/Interfaces/IPluginRepositoryService.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginRepositoryService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+/// <summary>
+/// 管理官方插件仓库只读缓存和 repo.json。
+/// </summary>
+public interface IPluginRepositoryService
+{
+    string RepositoryDirectory { get; }
+
+    PluginRepositorySnapshot? Current { get; }
+
+    PluginRepositorySettings Settings { get; }
+
+    Task<Result<PluginRepositorySnapshot>> InitializeAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<Result<PluginRepositorySnapshot>> RefreshAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<Result<PluginRepositorySnapshot>> ResetAsync(
+        CancellationToken cancellationToken = default);
+
+    Result SaveSettings(PluginRepositorySettings settings);
+}

--- a/AkashaNavigator/Core/Interfaces/IPluginUpdateService.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginUpdateService.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AkashaNavigator.Models.Common;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+/// <summary>
+/// 合并内置目录与远程插件包的统一更新服务。
+/// </summary>
+public interface IPluginUpdateService
+{
+    /// <summary>
+    /// 刷新远程清单并检查所有已安装插件的可用更新。
+    /// </summary>
+    Task<Result<IReadOnlyList<UpdateCheckResult>>> CheckAllUpdatesAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 按检查结果中记录的来源安装指定更新。
+    /// </summary>
+    Task<UpdateResult> UpdatePluginAsync(
+        UpdateCheckResult update,
+        CancellationToken cancellationToken = default);
+}

--- a/AkashaNavigator/Core/PluginUpdateChecker.cs
+++ b/AkashaNavigator/Core/PluginUpdateChecker.cs
@@ -20,7 +20,7 @@ namespace AkashaNavigator.Core
     /// </summary>
     public class PluginUpdateChecker
     {
-        private readonly IPluginLibrary _pluginLibrary;
+        private readonly IPluginUpdateService _pluginUpdateService;
         private readonly ProfileMarketplaceService _profileMarketplaceService;
         private readonly INotificationService _notificationService;
         private readonly IServiceProvider _serviceProvider;
@@ -32,7 +32,7 @@ namespace AkashaNavigator.Core
         /// 初始化 PluginUpdateChecker
         /// </summary>
         public PluginUpdateChecker(
-            IPluginLibrary pluginLibrary,
+            IPluginUpdateService pluginUpdateService,
             ProfileMarketplaceService profileMarketplaceService,
             INotificationService notificationService,
             IServiceProvider serviceProvider,
@@ -40,7 +40,8 @@ namespace AkashaNavigator.Core
             PlayerWindow playerWindow,
             AppConfig config)
         {
-            _pluginLibrary = pluginLibrary;
+            _pluginUpdateService =
+                pluginUpdateService ?? throw new ArgumentNullException(nameof(pluginUpdateService));
             _profileMarketplaceService = profileMarketplaceService;
             _notificationService = notificationService;
             _serviceProvider = serviceProvider;
@@ -81,18 +82,31 @@ namespace AkashaNavigator.Core
         {
             try
             {
-                var updates = _pluginLibrary.CheckAllUpdates();
+                var checkResult = await _pluginUpdateService.CheckAllUpdatesAsync();
+                if (checkResult.IsFailure)
+                {
+                    var logService = _serviceProvider.GetRequiredService<ILogService>();
+                    logService.Warn(
+                        nameof(PluginUpdateChecker),
+                        "检查远程插件更新失败，将继续检查 Profile: {ErrorMessage}",
+                        checkResult.Error?.Message ?? "未知错误");
+                    await CheckAndPromptProfileUpdatesAsync();
+                    return;
+                }
+
+                var updates = checkResult.Value!;
                 var continueCheckingProfiles = true;
 
                 if (updates.Count > 0)
                 {
                     var dialogFactory = _serviceProvider.GetRequiredService<IDialogFactory>();
-                    var dialog = dialogFactory.CreatePluginUpdatePromptDialog(updates);
+                    var dialog = dialogFactory.CreatePluginUpdatePromptDialog(
+                        new System.Collections.Generic.List<UpdateCheckResult>(updates));
                     var result = dialog.ShowDialog();
 
                     if (result == true)
                     {
-                        continueCheckingProfiles = HandlePluginUpdateDialogResult(dialog, updates);
+                        continueCheckingProfiles = await HandlePluginUpdateDialogResultAsync(dialog, updates);
                     }
                 }
 
@@ -111,8 +125,9 @@ namespace AkashaNavigator.Core
         /// <summary>
         /// 处理更新对话框结果
         /// </summary>
-        private bool HandlePluginUpdateDialogResult(PluginUpdatePromptDialog dialog,
-                                                    System.Collections.Generic.List<UpdateCheckResult> updates)
+        private async System.Threading.Tasks.Task<bool> HandlePluginUpdateDialogResultAsync(
+            PluginUpdatePromptDialog dialog,
+            System.Collections.Generic.IReadOnlyList<UpdateCheckResult> updates)
         {
             switch (dialog.Result)
             {
@@ -121,7 +136,7 @@ namespace AkashaNavigator.Core
                     return false;
 
                 case PluginUpdatePromptResult.UpdateAll:
-                    UpdateAllPlugins(updates);
+                    await UpdateAllPluginsAsync(updates);
                     return true;
 
                 default:
@@ -193,13 +208,14 @@ namespace AkashaNavigator.Core
         /// <summary>
         /// 执行一键更新所有插件
         /// </summary>
-        private void UpdateAllPlugins(System.Collections.Generic.List<UpdateCheckResult> updates)
+        private async System.Threading.Tasks.Task UpdateAllPluginsAsync(
+            System.Collections.Generic.IReadOnlyList<UpdateCheckResult> updates)
         {
             var successCount = 0;
             var failCount = 0;
             foreach (var update in updates)
             {
-                var updateResult = _pluginLibrary.UpdatePlugin(update.PluginId);
+                var updateResult = await _pluginUpdateService.UpdatePluginAsync(update);
                 if (updateResult.IsSuccess)
                     successCount++;
                 else

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -93,6 +93,9 @@ public static class ServiceCollectionExtensions
         // PluginPackageService（依赖 Manifest、下载源选择器和 PluginLibrary）
         services.AddSingleton<IPluginPackageService, PluginPackageService>();
 
+        // PluginUpdateService（统一合并内置目录与远程插件包更新）
+        services.AddSingleton<IPluginUpdateService, PluginUpdateService>();
+
         // PluginResourceUpdateService（仅在对应插件已安装时更新独立资源）
         services.AddSingleton<IPluginResourceUpdateService, PluginResourceUpdateService>();
 

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -81,6 +81,9 @@ public static class ServiceCollectionExtensions
         // ConfigService（依赖LogService）
         services.AddSingleton<IConfigService, ConfigService>();
 
+        // PluginRepositoryService（官方 catalog 缓存与索引）
+        services.AddSingleton<IPluginRepositoryService, PluginRepositoryService>();
+
         // ShutdownCoordinator（依赖 LogService，统一编排幂等关停阶段）
         services.AddSingleton<ShutdownCoordinator>();
 

--- a/AkashaNavigator/Helpers/AppPaths.cs
+++ b/AkashaNavigator/Helpers/AppPaths.cs
@@ -112,6 +112,21 @@ public static class AppPaths
     /// </summary>
     public static string PluginResourcesDirectory { get; }
 
+    /// <summary>
+    /// 插件仓库只读缓存根目录（User/Data/PluginRepositories/）。
+    /// </summary>
+    public static string PluginRepositoriesDirectory { get; }
+
+    /// <summary>
+    /// 官方插件仓库缓存目录。
+    /// </summary>
+    public static string OfficialPluginRepositoryDirectory { get; }
+
+    /// <summary>
+    /// 插件仓库配置文件。
+    /// </summary>
+    public static string PluginRepositoriesConfigFilePath { get; }
+
     static AppPaths()
     {
         // 获取应用程序目录
@@ -161,6 +176,11 @@ public static class AppPaths
         NoticeCacheFilePath = Path.Combine(UpdateDirectory, "notice-cache.json");
         NoticeStateFilePath = Path.Combine(UpdateDirectory, "notice-state.json");
         PluginResourcesDirectory = Path.Combine(DataDirectory, "PluginResources");
+        PluginRepositoriesDirectory = Path.Combine(DataDirectory, "PluginRepositories");
+        OfficialPluginRepositoryDirectory =
+            Path.Combine(PluginRepositoriesDirectory, AppConstants.OfficialPluginRepositoryId);
+        PluginRepositoriesConfigFilePath =
+            Path.Combine(DataDirectory, AppConstants.PluginRepositoriesConfigFileName);
 
         // 确保目录存在
         EnsureDirectoriesExist();
@@ -203,6 +223,7 @@ public static class AppPaths
         Directory.CreateDirectory(InstalledPluginsDirectory);
         Directory.CreateDirectory(UpdateDirectory);
         Directory.CreateDirectory(PluginResourcesDirectory);
+        Directory.CreateDirectory(PluginRepositoriesDirectory);
 
         // 为 WebView2 数据文件夹设置写权限
         EnsureWebView2FolderPermissions();

--- a/AkashaNavigator/Models/Common/PluginUpdateSource.cs
+++ b/AkashaNavigator/Models/Common/PluginUpdateSource.cs
@@ -1,0 +1,10 @@
+namespace AkashaNavigator.Models.Common;
+
+/// <summary>
+/// 插件更新包的来源。
+/// </summary>
+public enum PluginUpdateSource
+{
+    BuiltIn,
+    RemotePackage
+}

--- a/AkashaNavigator/Models/Common/UpdateCheckResult.cs
+++ b/AkashaNavigator/Models/Common/UpdateCheckResult.cs
@@ -27,6 +27,11 @@ public class UpdateCheckResult
     public bool HasUpdate { get; set; }
 
     /// <summary>
+    /// 更新包来源。
+    /// </summary>
+    public PluginUpdateSource Source { get; set; } = PluginUpdateSource.BuiltIn;
+
+    /// <summary>
     /// 更新源路径（内置插件目录路径）
     /// </summary>
     public string? SourcePath { get; set; }
@@ -74,6 +79,23 @@ public class UpdateCheckResult
     {
         return new UpdateCheckResult { PluginId = pluginId, CurrentVersion = currentVersion,
                                        AvailableVersion = availableVersion, HasUpdate = true, SourcePath = sourcePath };
+    }
+
+    /// <summary>
+    /// 创建远程插件包更新结果。
+    /// </summary>
+    public static UpdateCheckResult WithRemoteUpdate(
+        string pluginId,
+        string currentVersion,
+        string availableVersion)
+    {
+        return new UpdateCheckResult {
+            PluginId = pluginId,
+            CurrentVersion = currentVersion,
+            AvailableVersion = availableVersion,
+            HasUpdate = true,
+            Source = PluginUpdateSource.RemotePackage
+        };
     }
 }
 }

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositoryChannel.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositoryChannel.cs
@@ -1,0 +1,11 @@
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// 官方逻辑插件仓库的网络渠道。
+/// </summary>
+public enum PluginRepositoryChannel
+{
+    GitHub,
+    Cnb,
+    Custom
+}

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositoryIndex.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositoryIndex.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// catalog 分支根目录 repo.json。
+/// </summary>
+public sealed class PluginRepositoryIndex
+{
+    public int SchemaVersion { get; set; }
+
+    /// <summary>
+    /// 生成 catalog 的 main 源提交。
+    /// </summary>
+    public string Commit { get; set; } = string.Empty;
+
+    public List<PluginRepositoryEntry> Plugins { get; set; } = new();
+}
+
+/// <summary>
+/// repo.json 中的插件摘要。
+/// </summary>
+public sealed class PluginRepositoryEntry
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Path { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public string DistributionType { get; set; } = string.Empty;
+
+    public bool HasBackend { get; set; }
+
+    public string MinHostVersion { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 一次仓库读取或同步后的不可变快照。
+/// </summary>
+public sealed record PluginRepositorySnapshot(
+    PluginRepositoryIndex Index,
+    string CatalogCommit,
+    bool UsedCache);

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositorySettings.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositorySettings.cs
@@ -1,0 +1,30 @@
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// 官方插件仓库的本地配置。
+/// </summary>
+public sealed class PluginRepositorySettings
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public PluginRepositoryChannel SelectedChannel { get; set; } =
+        PluginRepositoryChannel.GitHub;
+
+    public string CustomUrl { get; set; } = string.Empty;
+
+    public string Branch { get; set; } = AppConstants.OfficialPluginRepositoryBranch;
+
+    public bool AutoUpdateRepository { get; set; } = true;
+
+    public bool AutoUpdateSubscribedPlugins { get; set; }
+
+    public string GetSelectedUrl()
+    {
+        return SelectedChannel switch {
+            PluginRepositoryChannel.GitHub => AppConstants.OfficialPluginRepositoryGitHubUrl,
+            PluginRepositoryChannel.Cnb => AppConstants.OfficialPluginRepositoryCnbUrl,
+            PluginRepositoryChannel.Custom => CustomUrl ?? string.Empty,
+            _ => string.Empty
+        };
+    }
+}

--- a/AkashaNavigator/Services/PluginRepositoryGitClient.cs
+++ b/AkashaNavigator/Services/PluginRepositoryGitClient.cs
@@ -1,0 +1,197 @@
+using System.IO;
+using LibGit2Sharp;
+
+namespace AkashaNavigator.Services;
+
+internal interface IPluginRepositoryGitClient
+{
+    Task<string> SynchronizeAsync(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken);
+
+    string? GetHeadCommit(string repositoryDirectory);
+}
+
+internal sealed class PluginRepositoryGitClient : IPluginRepositoryGitClient
+{
+    public Task<string> SynchronizeAsync(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () =>
+            {
+                try
+                {
+                    return Synchronize(
+                        repositoryUrl,
+                        branch,
+                        repositoryDirectory,
+                        reset,
+                        cancellationToken);
+                }
+                catch (UserCancelledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+            },
+            cancellationToken);
+    }
+
+    public string? GetHeadCommit(string repositoryDirectory)
+    {
+        if (!Repository.IsValid(repositoryDirectory))
+        {
+            return null;
+        }
+
+        using var repository = new Repository(repositoryDirectory);
+        return repository.Head.Tip?.Sha;
+    }
+
+    private static string Synchronize(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (reset && Directory.Exists(repositoryDirectory))
+        {
+            DeleteRepositoryCache(repositoryDirectory);
+        }
+
+        if (!Repository.IsValid(repositoryDirectory))
+        {
+            if (Directory.Exists(repositoryDirectory))
+            {
+                DeleteRepositoryCache(repositoryDirectory);
+            }
+
+            var cloneOptions = new CloneOptions(CreateFetchOptions(cancellationToken)) {
+                BranchName = branch,
+                Checkout = true,
+                RecurseSubmodules = false
+            };
+            Repository.Clone(repositoryUrl, repositoryDirectory, cloneOptions);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var cloned = new Repository(repositoryDirectory);
+            return cloned.Head.Tip?.Sha
+                   ?? throw new InvalidDataException("克隆后的 catalog 分支没有提交");
+        }
+
+        using var repository = new Repository(repositoryDirectory);
+        var remote = repository.Network.Remotes["origin"]
+                     ?? throw new InvalidDataException("插件仓库缺少 origin 远端");
+        if (!string.Equals(remote.Url, repositoryUrl, StringComparison.Ordinal))
+        {
+            repository.Network.Remotes.Update(
+                remote.Name,
+                update => update.Url = repositoryUrl);
+            remote = repository.Network.Remotes["origin"]!;
+        }
+
+        Commands.Fetch(
+            repository,
+            remote.Name,
+            new[] { $"+refs/heads/{branch}:refs/remotes/{remote.Name}/{branch}" },
+            CreateFetchOptions(cancellationToken),
+            null);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var remoteBranch = repository.Branches[$"{remote.Name}/{branch}"]
+                           ?? throw new InvalidDataException($"远端分支不存在: {branch}");
+        if (string.Equals(
+                repository.Head.FriendlyName,
+                branch,
+                StringComparison.Ordinal) &&
+            string.Equals(
+                repository.Head.Tip?.Sha,
+                remoteBranch.Tip.Sha,
+                StringComparison.Ordinal) &&
+            !repository.RetrieveStatus().IsDirty)
+        {
+            return remoteBranch.Tip.Sha;
+        }
+
+        var localBranch = repository.Branches[branch]
+                          ?? repository.CreateBranch(branch, remoteBranch.Tip);
+        Commands.Checkout(
+            repository,
+            localBranch,
+            new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+        repository.Reset(ResetMode.Hard, remoteBranch.Tip);
+        repository.Branches.Update(
+            localBranch,
+            update => update.TrackedBranch = remoteBranch.CanonicalName);
+
+        return remoteBranch.Tip.Sha;
+    }
+
+    private static FetchOptions CreateFetchOptions(
+        CancellationToken cancellationToken)
+    {
+        return new FetchOptions {
+            OnProgress = _ => !cancellationToken.IsCancellationRequested,
+            OnTransferProgress = _ => !cancellationToken.IsCancellationRequested
+        };
+    }
+
+    private static void DeleteRepositoryCache(string repositoryDirectory)
+    {
+        var fullPath = Path.TrimEndingDirectorySeparator(
+            Path.GetFullPath(repositoryDirectory));
+        var rootPath = Path.TrimEndingDirectorySeparator(
+            Path.GetPathRoot(fullPath) ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(Path.GetFileName(fullPath)) ||
+            string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("拒绝删除无效的插件仓库缓存路径");
+        }
+
+        DeleteDirectoryTree(fullPath);
+    }
+
+    private static void DeleteDirectoryTree(string directory)
+    {
+        foreach (var entryPath in Directory.EnumerateFileSystemEntries(directory))
+        {
+            var attributes = File.GetAttributes(entryPath);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                File.SetAttributes(entryPath, FileAttributes.Normal);
+                if ((attributes & FileAttributes.Directory) != 0)
+                {
+                    Directory.Delete(entryPath);
+                }
+                else
+                {
+                    File.Delete(entryPath);
+                }
+
+                continue;
+            }
+
+            if ((attributes & FileAttributes.Directory) != 0)
+            {
+                DeleteDirectoryTree(entryPath);
+                continue;
+            }
+
+            File.SetAttributes(entryPath, attributes & ~FileAttributes.ReadOnly);
+            File.Delete(entryPath);
+        }
+
+        File.SetAttributes(directory, FileAttributes.Normal);
+        Directory.Delete(directory);
+    }
+}

--- a/AkashaNavigator/Services/PluginRepositoryService.cs
+++ b/AkashaNavigator/Services/PluginRepositoryService.cs
@@ -1,0 +1,364 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 官方插件仓库缓存服务。
+/// </summary>
+public sealed class PluginRepositoryService : IPluginRepositoryService
+{
+    private readonly ILogService _logService;
+    private readonly IPluginRepositoryGitClient _gitClient;
+    private readonly string _repositoryDirectory;
+    private readonly string _settingsFilePath;
+    private readonly object _settingsLock = new();
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    private PluginRepositorySnapshot? _current;
+    private PluginRepositorySettings _settings;
+
+    public PluginRepositoryService(ILogService logService)
+        : this(
+            logService,
+            new PluginRepositoryGitClient(),
+            AppPaths.OfficialPluginRepositoryDirectory,
+            AppPaths.PluginRepositoriesConfigFilePath)
+    {
+    }
+
+    internal PluginRepositoryService(
+        ILogService logService,
+        IPluginRepositoryGitClient gitClient,
+        string repositoryDirectory,
+        string settingsFilePath)
+    {
+        _logService = logService ?? throw new ArgumentNullException(nameof(logService));
+        _gitClient = gitClient ?? throw new ArgumentNullException(nameof(gitClient));
+        _repositoryDirectory =
+            repositoryDirectory ?? throw new ArgumentNullException(nameof(repositoryDirectory));
+        _settingsFilePath =
+            settingsFilePath ?? throw new ArgumentNullException(nameof(settingsFilePath));
+        _settings = LoadSettings();
+        _current = LoadSnapshot(usedCache: true).Value;
+    }
+
+    public PluginRepositorySnapshot? Current => Volatile.Read(ref _current);
+
+    public string RepositoryDirectory => _repositoryDirectory;
+
+    public PluginRepositorySettings Settings
+    {
+        get
+        {
+            lock (_settingsLock)
+            {
+                return CloneSettings(_settings);
+            }
+        }
+    }
+
+    public async Task<Result<PluginRepositorySnapshot>> InitializeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var cached = Current;
+        if (cached != null)
+        {
+            return Result<PluginRepositorySnapshot>.Success(cached);
+        }
+
+        return await RefreshCoreAsync(reset: false, allowCacheFallback: false, cancellationToken);
+    }
+
+    public Task<Result<PluginRepositorySnapshot>> RefreshAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return RefreshCoreAsync(reset: false, allowCacheFallback: true, cancellationToken);
+    }
+
+    public Task<Result<PluginRepositorySnapshot>> ResetAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return RefreshCoreAsync(reset: true, allowCacheFallback: false, cancellationToken);
+    }
+
+    public Result SaveSettings(PluginRepositorySettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        var validation = ValidateSettings(settings);
+        if (validation != null)
+        {
+            return Result.Failure(validation);
+        }
+
+        lock (_settingsLock)
+        {
+            var saveResult = JsonHelper.SaveToFile(_settingsFilePath, settings);
+            if (saveResult.IsFailure)
+            {
+                return saveResult;
+            }
+
+            _settings = CloneSettings(settings);
+        }
+
+        return Result.Success();
+    }
+
+    private async Task<Result<PluginRepositorySnapshot>> RefreshCoreAsync(
+        bool reset,
+        bool allowCacheFallback,
+        CancellationToken cancellationToken)
+    {
+        var lockTaken = false;
+        var settings = Settings;
+        try
+        {
+            await _writeLock.WaitAsync(cancellationToken);
+            lockTaken = true;
+
+            settings = Settings;
+            var validation = ValidateSettings(settings);
+            if (validation != null)
+            {
+                return UseCacheOrFailure(validation, allowCacheFallback);
+            }
+
+            var repositoryUrl = settings.GetSelectedUrl();
+            await _gitClient.SynchronizeAsync(
+                repositoryUrl,
+                settings.Branch,
+                _repositoryDirectory,
+                reset,
+                cancellationToken);
+
+            var snapshotResult = LoadSnapshot(usedCache: false);
+            if (snapshotResult.IsFailure)
+            {
+                return UseCacheOrFailure(snapshotResult.Error!, allowCacheFallback);
+            }
+
+            Volatile.Write(ref _current, snapshotResult.Value);
+            return snapshotResult;
+        }
+        catch (OperationCanceledException ex)
+        {
+            return UseCacheOrFailure(
+                Error.Network(
+                    "PLUGIN_REPOSITORY_SYNC_CANCELED",
+                    "插件仓库同步已取消",
+                    ex,
+                    settings.GetSelectedUrl()),
+                allowCacheFallback);
+        }
+        catch (Exception ex)
+        {
+            return UseCacheOrFailure(
+                Error.Network(
+                    "PLUGIN_REPOSITORY_SYNC_FAILED",
+                    ex.Message,
+                    ex,
+                    settings.GetSelectedUrl()),
+                allowCacheFallback);
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                _writeLock.Release();
+            }
+        }
+    }
+
+    private Result<PluginRepositorySnapshot> LoadSnapshot(bool usedCache)
+    {
+        try
+        {
+            var indexPath = Path.Combine(
+                _repositoryDirectory,
+                AppConstants.PluginRepositoryIndexFileName);
+            var loadResult = JsonHelper.LoadFromFile<PluginRepositoryIndex>(indexPath);
+            if (loadResult.IsFailure)
+            {
+                return Result<PluginRepositorySnapshot>.Failure(loadResult.Error!);
+            }
+
+            var validation = ValidateIndex(loadResult.Value!);
+            if (validation != null)
+            {
+                return Result<PluginRepositorySnapshot>.Failure(validation);
+            }
+
+            var catalogCommit = _gitClient.GetHeadCommit(_repositoryDirectory);
+            if (!IsCommitSha(catalogCommit))
+            {
+                return Result<PluginRepositorySnapshot>.Failure(
+                    Error.FileSystem(
+                        "PLUGIN_REPOSITORY_HEAD_MISSING",
+                        "插件仓库缓存没有有效的 catalog HEAD",
+                        filePath: _repositoryDirectory));
+            }
+
+            return Result<PluginRepositorySnapshot>.Success(
+                new PluginRepositorySnapshot(loadResult.Value!, catalogCommit!, usedCache));
+        }
+        catch (Exception ex)
+        {
+            return Result<PluginRepositorySnapshot>.Failure(
+                Error.FileSystem(
+                    "PLUGIN_REPOSITORY_CACHE_INVALID",
+                    $"读取插件仓库缓存失败: {ex.Message}",
+                    ex,
+                    _repositoryDirectory));
+        }
+    }
+
+    private Result<PluginRepositorySnapshot> UseCacheOrFailure(
+        Error error,
+        bool allowCacheFallback)
+    {
+        var cached = Current;
+        if (!allowCacheFallback || cached == null)
+        {
+            return Result<PluginRepositorySnapshot>.Failure(error);
+        }
+
+        _logService.Warn(
+            nameof(PluginRepositoryService),
+            "插件仓库同步失败，继续使用本地缓存: {ErrorMessage}",
+            error.Message);
+        return Result<PluginRepositorySnapshot>.Success(
+            cached with { UsedCache = true });
+    }
+
+    private PluginRepositorySettings LoadSettings()
+    {
+        var result = JsonHelper.LoadFromFile<PluginRepositorySettings>(_settingsFilePath);
+        if (result.IsSuccess && ValidateSettings(result.Value!) == null)
+        {
+            return result.Value!;
+        }
+
+        return new PluginRepositorySettings();
+    }
+
+    private static Error? ValidateSettings(PluginRepositorySettings settings)
+    {
+        if (settings.SchemaVersion != 1)
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_SETTINGS_VERSION_INVALID",
+                $"不支持的插件仓库配置版本: {settings.SchemaVersion}");
+        }
+
+        if (!Enum.IsDefined(settings.SelectedChannel))
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_CHANNEL_INVALID",
+                $"不支持的插件仓库渠道: {settings.SelectedChannel}");
+        }
+
+        if (!string.Equals(
+                settings.Branch,
+                AppConstants.OfficialPluginRepositoryBranch,
+                StringComparison.Ordinal))
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_BRANCH_INVALID",
+                $"官方插件仓库分支必须是 {AppConstants.OfficialPluginRepositoryBranch}");
+        }
+
+        var url = settings.GetSelectedUrl();
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_URL_INVALID",
+                "插件仓库地址必须是有效的 HTTPS URL");
+        }
+
+        return null;
+    }
+
+    private static Error? ValidateIndex(PluginRepositoryIndex index)
+    {
+        if (index.SchemaVersion != 1 ||
+            !IsCommitSha(index.Commit) ||
+            index.Plugins == null)
+        {
+            return Error.Serialization(
+                "PLUGIN_REPOSITORY_INDEX_INVALID",
+                "repo.json schemaVersion 或源提交无效");
+        }
+
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? previousId = null;
+        foreach (var plugin in index.Plugins)
+        {
+            if (plugin == null)
+            {
+                return Error.Serialization(
+                    "PLUGIN_REPOSITORY_ENTRY_INVALID",
+                    "repo.json 包含 null 插件条目");
+            }
+
+            if (!PluginIdValidator.IsValid(plugin.Id) ||
+                !seenIds.Add(plugin.Id) ||
+                !string.Equals(
+                    plugin.Path,
+                    $"{AppConstants.PluginsDirectoryName}/{plugin.Id}",
+                    StringComparison.Ordinal) ||
+                string.IsNullOrWhiteSpace(plugin.Name) ||
+                !IsSemanticVersion(plugin.Version) ||
+                string.IsNullOrWhiteSpace(plugin.Description) ||
+                (plugin.DistributionType != AppConstants.PluginDistributionRepository &&
+                 plugin.DistributionType != AppConstants.PluginDistributionRelease) ||
+                !IsSemanticVersion(plugin.MinHostVersion) ||
+                (previousId != null &&
+                 string.CompareOrdinal(previousId, plugin.Id) >= 0))
+            {
+                return Error.Serialization(
+                    "PLUGIN_REPOSITORY_ENTRY_INVALID",
+                    $"repo.json 包含无效或未稳定排序的插件条目: {plugin.Id}");
+            }
+
+            previousId = plugin.Id;
+        }
+
+        return null;
+    }
+
+    private static bool IsCommitSha(string? value)
+    {
+        return value != null &&
+               value.Length is 40 or 64 &&
+               Regex.IsMatch(value, "^[0-9a-f]+$", RegexOptions.CultureInvariant);
+    }
+
+    private static bool IsSemanticVersion(string? value)
+    {
+        return value != null &&
+               Regex.IsMatch(
+                   value,
+                   "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+                   RegexOptions.CultureInvariant);
+    }
+
+    private static PluginRepositorySettings CloneSettings(
+        PluginRepositorySettings settings)
+    {
+        return new PluginRepositorySettings {
+            SchemaVersion = settings.SchemaVersion,
+            SelectedChannel = settings.SelectedChannel,
+            CustomUrl = settings.CustomUrl ?? string.Empty,
+            Branch = settings.Branch ?? string.Empty,
+            AutoUpdateRepository = settings.AutoUpdateRepository,
+            AutoUpdateSubscribedPlugins = settings.AutoUpdateSubscribedPlugins
+        };
+    }
+}

--- a/AkashaNavigator/Services/PluginUpdateService.cs
+++ b/AkashaNavigator/Services/PluginUpdateService.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 合并旧版内置插件目录更新与远程插件包更新。
+/// </summary>
+public sealed class PluginUpdateService : IPluginUpdateService
+{
+    private readonly IPluginLibrary _pluginLibrary;
+    private readonly IUpdateManifestService _updateManifestService;
+    private readonly IPluginPackageService _pluginPackageService;
+
+    public PluginUpdateService(
+        IPluginLibrary pluginLibrary,
+        IUpdateManifestService updateManifestService,
+        IPluginPackageService pluginPackageService)
+    {
+        _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
+        _updateManifestService =
+            updateManifestService ?? throw new ArgumentNullException(nameof(updateManifestService));
+        _pluginPackageService =
+            pluginPackageService ?? throw new ArgumentNullException(nameof(pluginPackageService));
+    }
+
+    public async Task<Result<IReadOnlyList<UpdateCheckResult>>> CheckAllUpdatesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var manifestResult = await _updateManifestService.RefreshAsync(cancellationToken);
+        if (manifestResult.IsFailure)
+        {
+            return Result<IReadOnlyList<UpdateCheckResult>>.Failure(manifestResult.Error!);
+        }
+
+        var installed = _pluginLibrary.GetInstalledPlugins()
+            .ToDictionary(plugin => plugin.Id, StringComparer.OrdinalIgnoreCase);
+        var candidates = _pluginLibrary.CheckAllUpdates()
+            .ToDictionary(update => update.PluginId, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var remote in _pluginPackageService.GetRemoteCatalog())
+        {
+            if (!installed.TryGetValue(remote.Id, out var installedPlugin) ||
+                PluginLibrary.CompareVersions(remote.Version, installedPlugin.Version) <= 0)
+            {
+                continue;
+            }
+
+            if (candidates.TryGetValue(remote.Id, out var existing) &&
+                PluginLibrary.CompareVersions(existing.AvailableVersion, remote.Version) >= 0)
+            {
+                continue;
+            }
+
+            candidates[remote.Id] = UpdateCheckResult.WithRemoteUpdate(
+                remote.Id,
+                installedPlugin.Version,
+                remote.Version);
+        }
+
+        return Result<IReadOnlyList<UpdateCheckResult>>.Success(
+            candidates.Values
+                .OrderBy(update => update.PluginId, StringComparer.OrdinalIgnoreCase)
+                .ToList());
+    }
+
+    public async Task<UpdateResult> UpdatePluginAsync(
+        UpdateCheckResult update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        if (!update.HasUpdate || string.IsNullOrWhiteSpace(update.PluginId))
+        {
+            return UpdateResult.NoUpdateAvailable();
+        }
+
+        if (update.Source == PluginUpdateSource.BuiltIn)
+        {
+            return _pluginLibrary.UpdatePlugin(update.PluginId);
+        }
+
+        var oldVersion =
+            _pluginLibrary.GetInstalledPluginInfo(update.PluginId)?.Version ?? update.CurrentVersion;
+        var result = await _pluginPackageService.InstallOrUpdateAsync(
+            update.PluginId,
+            cancellationToken: cancellationToken);
+
+        return result.IsSuccess
+            ? UpdateResult.Success(oldVersion, result.Value!.Version)
+            : UpdateResult.Failed(result.Error?.Message ?? "远程插件更新失败");
+    }
+}

--- a/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
@@ -13,6 +13,7 @@ using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Models.Config;
 using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
 using AkashaNavigator.Models.Update;
 using AkashaNavigator.Helpers;
 using AkashaNavigator.Services;
@@ -28,7 +29,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     private readonly IPluginLibrary _pluginLibrary;
     private readonly INotificationService _notificationService;
     private readonly IEventBus _eventBus;
-    private readonly IUpdateManifestService _updateManifestService;
+    private readonly IPluginRepositoryService _pluginRepositoryService;
     private readonly IPluginPackageService _pluginPackageService;
     private readonly IConfigService _configService;
     private readonly Dictionary<string, CancellationTokenSource> _downloads =
@@ -59,6 +60,27 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     [ObservableProperty]
     private bool _isEmpty;
 
+    [ObservableProperty]
+    private PluginRepositoryChannel _selectedRepositoryChannel;
+
+    [ObservableProperty]
+    private string _customRepositoryUrl = string.Empty;
+
+    [ObservableProperty]
+    private bool _autoUpdateRepository;
+
+    [ObservableProperty]
+    private bool _autoUpdateSubscribedPlugins;
+
+    [ObservableProperty]
+    private bool _isRepositoryBusy;
+
+    [ObservableProperty]
+    private string _repositoryStatusText = "尚未加载插件仓库";
+
+    public bool IsCustomRepositoryChannel =>
+        SelectedRepositoryChannel == PluginRepositoryChannel.Custom;
+
     /// <summary>
     /// 构造函数
     /// </summary>
@@ -66,18 +88,21 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         IPluginLibrary pluginLibrary,
         INotificationService notificationService,
         IEventBus eventBus,
-        IUpdateManifestService updateManifestService,
+        IPluginRepositoryService pluginRepositoryService,
         IPluginPackageService pluginPackageService,
         IConfigService configService)
     {
         _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
-        _updateManifestService =
-            updateManifestService ?? throw new ArgumentNullException(nameof(updateManifestService));
+        _pluginRepositoryService =
+            pluginRepositoryService ?? throw new ArgumentNullException(nameof(pluginRepositoryService));
         _pluginPackageService =
             pluginPackageService ?? throw new ArgumentNullException(nameof(pluginPackageService));
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
+
+        LoadRepositorySettings();
+        UpdateRepositoryStatus(_pluginRepositoryService.Current);
 
         // 订阅插件列表变化事件
         _eventBus.Subscribe<PluginListChangedEvent>(OnPluginListChanged);
@@ -99,11 +124,18 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     {
         RefreshPluginList();
 
-        var refreshResult = await _updateManifestService.RefreshAsync();
-        if (refreshResult.IsSuccess)
+        var initializeResult = await _pluginRepositoryService.InitializeAsync();
+        if (initializeResult.IsSuccess)
         {
+            UpdateRepositoryStatus(initializeResult.Value);
             RefreshPluginList();
+            return;
         }
+
+        RepositoryStatusText = "插件仓库不可用";
+        _notificationService.Show(
+            $"加载插件仓库失败: {initializeResult.Error?.Message}",
+            NotificationType.Error);
     }
 
     /// <summary>
@@ -149,44 +181,74 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     /// </summary>
     private List<AvailablePluginItemModel> GetAllCatalogPlugins()
     {
-        var catalog = new Dictionary<string, PluginCatalogEntry>(StringComparer.OrdinalIgnoreCase);
         var installed = _pluginLibrary.GetInstalledPlugins()
             .ToDictionary(plugin => plugin.Id, StringComparer.OrdinalIgnoreCase);
-
-        // 扫描内置插件目录
-        var builtinPluginsDir = AppPaths.BuiltInPluginsDirectory;
-        if (Directory.Exists(builtinPluginsDir))
+        var snapshot = _pluginRepositoryService.Current;
+        if (snapshot == null)
         {
-            foreach (var pluginDir in Directory.GetDirectories(builtinPluginsDir))
-            {
-                var manifestPath = Path.Combine(pluginDir, "plugin.json");
-                if (!File.Exists(manifestPath))
-                    continue;
-
-                var manifest = JsonHelper.LoadFromFile<PluginManifest>(manifestPath);
-                if (manifest.IsFailure || string.IsNullOrEmpty(manifest.Value!.Id))
-                    continue;
-
-                catalog[manifest.Value.Id] = new PluginCatalogEntry {
-                    Id = manifest.Value.Id,
-                    Name = manifest.Value.Name ?? manifest.Value.Id,
-                    Version = manifest.Value.Version ?? "1.0.0",
-                    Description = manifest.Value.Description,
-                    Author = manifest.Value.Author,
-                    LocalSourceDirectory = pluginDir
-                };
-            }
+            return new List<AvailablePluginItemModel>();
         }
 
-        foreach (var remote in _pluginPackageService.GetRemoteCatalog())
-        {
-            catalog[remote.Id] = remote;
-        }
-
-        return catalog.Values
-            .Select(entry => CreateItem(entry, installed.GetValueOrDefault(entry.Id)))
+        return snapshot.Index.Plugins
+            .Select(
+                entry => CreateItem(
+                    CreateCatalogEntry(entry),
+                    installed.GetValueOrDefault(entry.Id)))
             .OrderBy(item => item.Name, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
+    }
+
+    [RelayCommand]
+    private void SaveRepositorySettings()
+    {
+        var result = TrySaveRepositorySettings();
+        _notificationService.Show(
+            result.IsSuccess
+                ? "插件仓库设置已保存"
+                : $"保存插件仓库设置失败: {result.Error?.Message}",
+            result.IsSuccess ? NotificationType.Success : NotificationType.Error);
+    }
+
+    [RelayCommand]
+    private async Task UpdateRepositoryAsync()
+    {
+        if (!CanStartRepositoryOperation())
+        {
+            return;
+        }
+
+        IsRepositoryBusy = true;
+        RepositoryStatusText = "正在更新插件仓库…";
+        try
+        {
+            var result = await _pluginRepositoryService.RefreshAsync();
+            HandleRepositoryUpdateResult(result, "插件仓库已更新");
+        }
+        finally
+        {
+            IsRepositoryBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ResetRepositoryAsync()
+    {
+        if (!CanStartRepositoryOperation())
+        {
+            return;
+        }
+
+        IsRepositoryBusy = true;
+        RepositoryStatusText = "正在重置插件仓库…";
+        try
+        {
+            var result = await _pluginRepositoryService.ResetAsync();
+            HandleRepositoryUpdateResult(result, "插件仓库已重置");
+        }
+        finally
+        {
+            IsRepositoryBusy = false;
+        }
     }
 
     /// <summary>
@@ -311,6 +373,105 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             SelectedSourceText = entry.IsRemote
                 ? $"下载源：{GetPreferenceDisplayName(_configService.Config.PluginDownloadSourcePreference)}"
                 : string.Empty
+        };
+    }
+
+    partial void OnSelectedRepositoryChannelChanged(PluginRepositoryChannel value)
+    {
+        OnPropertyChanged(nameof(IsCustomRepositoryChannel));
+    }
+
+    private void LoadRepositorySettings()
+    {
+        var settings = _pluginRepositoryService.Settings;
+        SelectedRepositoryChannel = settings.SelectedChannel;
+        CustomRepositoryUrl = settings.CustomUrl;
+        AutoUpdateRepository = settings.AutoUpdateRepository;
+        AutoUpdateSubscribedPlugins = settings.AutoUpdateSubscribedPlugins;
+    }
+
+    private Result TrySaveRepositorySettings()
+    {
+        return _pluginRepositoryService.SaveSettings(
+            new PluginRepositorySettings {
+                SelectedChannel = SelectedRepositoryChannel,
+                CustomUrl = CustomRepositoryUrl.Trim(),
+                Branch = AppConstants.OfficialPluginRepositoryBranch,
+                AutoUpdateRepository = AutoUpdateRepository,
+                AutoUpdateSubscribedPlugins = AutoUpdateSubscribedPlugins
+            });
+    }
+
+    private bool CanStartRepositoryOperation()
+    {
+        if (IsRepositoryBusy)
+        {
+            return false;
+        }
+
+        var saveResult = TrySaveRepositorySettings();
+        if (saveResult.IsSuccess)
+        {
+            return true;
+        }
+
+        _notificationService.Show(
+            $"插件仓库设置无效: {saveResult.Error?.Message}",
+            NotificationType.Error);
+        return false;
+    }
+
+    private void HandleRepositoryUpdateResult(
+        Result<PluginRepositorySnapshot> result,
+        string successMessage)
+    {
+        if (result.IsFailure)
+        {
+            RepositoryStatusText = "插件仓库更新失败";
+            _notificationService.Show(
+                $"{RepositoryStatusText}: {result.Error?.Message}",
+                NotificationType.Error);
+            return;
+        }
+
+        UpdateRepositoryStatus(result.Value);
+        RefreshPluginList();
+        _notificationService.Show(
+            result.Value!.UsedCache
+                ? "仓库更新失败，已继续使用本地缓存"
+                : successMessage,
+            result.Value.UsedCache ? NotificationType.Warning : NotificationType.Success);
+    }
+
+    private void UpdateRepositoryStatus(PluginRepositorySnapshot? snapshot)
+    {
+        if (snapshot == null)
+        {
+            RepositoryStatusText = "尚未加载插件仓库";
+            return;
+        }
+
+        var shortCommit = snapshot.CatalogCommit.Length > 8
+            ? snapshot.CatalogCommit[..8]
+            : snapshot.CatalogCommit;
+        RepositoryStatusText =
+            $"{(snapshot.UsedCache ? "本地缓存" : "最新仓库")} · {snapshot.Index.Plugins.Count} 个插件 · {shortCommit}";
+    }
+
+    private PluginCatalogEntry CreateCatalogEntry(PluginRepositoryEntry entry)
+    {
+        var isRelease =
+            entry.DistributionType == AppConstants.PluginDistributionRelease;
+        return new PluginCatalogEntry {
+            Id = entry.Id,
+            Name = entry.Name,
+            Version = entry.Version,
+            Description = entry.Description,
+            MinHostVersion = entry.MinHostVersion,
+            LocalSourceDirectory = isRelease
+                ? null
+                : Path.Combine(_pluginRepositoryService.RepositoryDirectory, entry.Path),
+            IsRemote = isRelease
         };
     }
 

--- a/AkashaNavigator/ViewModels/Pages/InstalledPluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/InstalledPluginsPageViewModel.cs
@@ -20,6 +20,7 @@ namespace AkashaNavigator.ViewModels.Pages
 public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposable
 {
     private readonly IPluginLibrary _pluginLibrary;
+    private readonly IPluginUpdateService _pluginUpdateService;
     private readonly IPluginAssociationManager _pluginAssociationManager;
     private readonly INotificationService _notificationService;
     private readonly IEventBus _eventBus;
@@ -56,10 +57,13 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// 构造函数
     /// </summary>
     public InstalledPluginsPageViewModel(IPluginLibrary pluginLibrary,
+                                         IPluginUpdateService pluginUpdateService,
                                          IPluginAssociationManager pluginAssociationManager,
                                          INotificationService notificationService, IEventBus eventBus)
     {
         _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
+        _pluginUpdateService =
+            pluginUpdateService ?? throw new ArgumentNullException(nameof(pluginUpdateService));
         _pluginAssociationManager =
             pluginAssociationManager ?? throw new ArgumentNullException(nameof(pluginAssociationManager));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
@@ -73,9 +77,9 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// <summary>
     /// 插件列表变化事件处理
     /// </summary>
-    private void OnPluginListChanged(PluginListChangedEvent e)
+    private async void OnPluginListChanged(PluginListChangedEvent e)
     {
-        CheckAndRefreshPluginList();
+        await CheckAndRefreshPluginListAsync();
     }
 
     /// <summary>
@@ -90,9 +94,9 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// 页面加载时检查更新并刷新插件列表
     /// </summary>
     [RelayCommand]
-    public void OnLoaded()
+    public async Task OnLoadedAsync()
     {
-        CheckAndRefreshPluginList();
+        await CheckAndRefreshPluginListAsync();
     }
 
     /// <summary>
@@ -106,10 +110,12 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// <summary>
     /// 检查更新并刷新插件列表
     /// </summary>
-    public void CheckAndRefreshPluginList()
+    public async Task CheckAndRefreshPluginListAsync()
     {
-        var updates = _pluginLibrary.CheckAllUpdates();
-        _updateCache = updates.ToDictionary(u => u.PluginId, u => u) ?? new Dictionary<string, UpdateCheckResult>();
+        var result = await _pluginUpdateService.CheckAllUpdatesAsync();
+        _updateCache = result.IsSuccess
+            ? result.Value!.ToDictionary(update => update.PluginId, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, UpdateCheckResult>(StringComparer.OrdinalIgnoreCase);
         RefreshPluginList();
     }
 
@@ -185,10 +191,21 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// 检查更新命令（自动生成 CheckUpdateCommand）
     /// </summary>
     [RelayCommand]
-    private void CheckUpdate()
+    private async Task CheckUpdateAsync()
     {
-        var updates = _pluginLibrary.CheckAllUpdates();
-        _updateCache = updates.ToDictionary(u => u.PluginId, u => u) ?? new Dictionary<string, UpdateCheckResult>();
+        var result = await _pluginUpdateService.CheckAllUpdatesAsync();
+        if (result.IsFailure)
+        {
+            _notificationService.Show(
+                $"检查插件更新失败: {result.Error?.Message}",
+                NotificationType.Error);
+            return;
+        }
+
+        var updates = result.Value!;
+        _updateCache = updates.ToDictionary(
+            update => update.PluginId,
+            StringComparer.OrdinalIgnoreCase);
 
         if (updates.Count == 0)
         {
@@ -205,7 +222,7 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
     /// 更新插件命令（自动生成 UpdatePluginCommand）
     /// </summary>
     [RelayCommand]
-    private void UpdatePlugin(string? pluginId)
+    private async Task UpdatePluginAsync(string? pluginId)
     {
         if (string.IsNullOrWhiteSpace(pluginId))
             return;
@@ -213,12 +230,18 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
         var pluginInfo = _pluginLibrary.GetInstalledPluginInfo(pluginId);
         var pluginName = pluginInfo?.Name ?? pluginId;
 
-        var result = _pluginLibrary.UpdatePlugin(pluginId);
+        if (!_updateCache.TryGetValue(pluginId, out var update))
+        {
+            _notificationService.Show("请先检查插件更新", NotificationType.Info);
+            return;
+        }
+
+        var result = await _pluginUpdateService.UpdatePluginAsync(update);
 
         if (result.IsSuccess)
         {
             _notificationService.Show($"{pluginName} 已更新到 v{result.NewVersion}", NotificationType.Success);
-            CheckAndRefreshPluginList();
+            await CheckAndRefreshPluginListAsync();
         }
         else
         {

--- a/AkashaNavigator/ViewModels/Windows/PluginCenterViewModel.cs
+++ b/AkashaNavigator/ViewModels/Windows/PluginCenterViewModel.cs
@@ -87,7 +87,7 @@ public partial class PluginCenterViewModel : ObservableObject
             _ = _profileMarketPageVM.LoadProfilesAsync();
             break;
         case PluginCenterPageType.InstalledPlugins:
-            _installedPluginsPageVM.CheckAndRefreshPluginList();
+            _ = _installedPluginsPageVM.CheckAndRefreshPluginListAsync();
             break;
         case PluginCenterPageType.AvailablePlugins:
             _availablePluginsPageVM.RefreshPluginList();
@@ -110,7 +110,7 @@ public partial class PluginCenterViewModel : ObservableObject
             _ = _profileMarketPageVM.LoadProfilesAsync();
             break;
         case PluginCenterPageType.InstalledPlugins:
-            _installedPluginsPageVM.CheckAndRefreshPluginList();
+            _ = _installedPluginsPageVM.CheckAndRefreshPluginListAsync();
             break;
         case PluginCenterPageType.AvailablePlugins:
             _availablePluginsPageVM.RefreshPluginList();

--- a/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
+++ b/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:AkashaNavigator.ViewModels.Pages"
+             xmlns:repository="clr-namespace:AkashaNavigator.Models.PluginRepository"
              Background="Transparent"
              Cursor="Arrow">
 
@@ -12,6 +13,7 @@
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -35,13 +37,44 @@
                      Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
 
+        <!-- 仓库设置 -->
+        <WrapPanel Grid.Row="1" Margin="0,0,0,12" VerticalAlignment="Center">
+            <ComboBox Width="105" Margin="0,0,8,0"
+                      SelectedValuePath="Tag"
+                      SelectedValue="{Binding SelectedRepositoryChannel}">
+                <ComboBoxItem Content="GitHub"
+                              Tag="{x:Static repository:PluginRepositoryChannel.GitHub}"/>
+                <ComboBoxItem Content="CNB"
+                              Tag="{x:Static repository:PluginRepositoryChannel.Cnb}"/>
+                <ComboBoxItem Content="自定义"
+                              Tag="{x:Static repository:PluginRepositoryChannel.Custom}"/>
+            </ComboBox>
+            <TextBox Width="250" Margin="0,0,8,0"
+                     Text="{Binding CustomRepositoryUrl, UpdateSourceTrigger=PropertyChanged}"
+                     ToolTip="自定义仓库 HTTPS Git 地址"
+                     Visibility="{Binding IsCustomRepositoryChannel, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            <CheckBox Content="启动时更新仓库" Margin="0,0,12,0"
+                      Foreground="#CCC" VerticalAlignment="Center"
+                      IsChecked="{Binding AutoUpdateRepository}"/>
+            <Button Content="保存" Style="{StaticResource ActionButtonStyle}"
+                    Margin="0,0,8,0"
+                    Command="{Binding SaveRepositorySettingsCommand}"/>
+            <Button Content="更新仓库" Style="{StaticResource PrimaryActionButtonStyle}"
+                    Margin="0,0,8,0"
+                    Command="{Binding UpdateRepositoryCommand}"/>
+            <Button Content="重置仓库" Style="{StaticResource ActionButtonStyle}"
+                    Command="{Binding ResetRepositoryCommand}"/>
+        </WrapPanel>
+
         <!-- 统计信息 -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,16">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,16">
             <TextBlock x:Name="PluginCountText" Text="{Binding PluginCountText}" Foreground="#888" FontSize="12"/>
+            <TextBlock Text="{Binding RepositoryStatusText}" Foreground="#60A5FA"
+                       FontSize="12" Margin="16,0,0,0"/>
         </StackPanel>
 
         <!-- 插件列表 -->
-        <ScrollViewer Grid.Row="2" Style="{StaticResource DarkScrollViewer}"
+        <ScrollViewer Grid.Row="3" Style="{StaticResource DarkScrollViewer}"
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <!-- 无插件提示 -->

--- a/AkashaNavigator/Views/Pages/InstalledPluginsPage.xaml.cs
+++ b/AkashaNavigator/Views/Pages/InstalledPluginsPage.xaml.cs
@@ -35,10 +35,10 @@ public partial class InstalledPluginsPage : UserControl, IDisposable
         Loaded += InstalledPluginsPage_Loaded;
     }
 
-    private void InstalledPluginsPage_Loaded(object sender, RoutedEventArgs e)
+    private async void InstalledPluginsPage_Loaded(object sender, RoutedEventArgs e)
     {
         // 委托给 ViewModel 的 OnLoaded 方法
-        _viewModel.OnLoaded();
+        await _viewModel.OnLoadedAsync();
     }
 
     /// <summary>
@@ -52,9 +52,9 @@ public partial class InstalledPluginsPage : UserControl, IDisposable
     /// <summary>
     /// 检查更新并刷新插件列表（公共方法）
     /// </summary>
-    public void CheckAndRefreshPluginList()
+    public async System.Threading.Tasks.Task CheckAndRefreshPluginListAsync()
     {
-        _viewModel.CheckAndRefreshPluginList();
+        await _viewModel.CheckAndRefreshPluginListAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
Superseded by #26.

This PR was based on a local `main` commit that had not yet reached GitHub, so it unintentionally included an unrelated prior change. #26 contains only the Phase 2 repository-client commit on top of the current remote `main`.