### PR TITLE
feat(plugins): add catalog repository client

### DIFF
--- a/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
+++ b/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
@@ -98,6 +98,19 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public void ConfigureAppServices_RegistersPluginRepositoryServiceAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.ConfigureAppServices();
+
+        var descriptor = services.Single(
+            service => service.ServiceType == typeof(IPluginRepositoryService));
+
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        Assert.Equal(typeof(PluginRepositoryService), descriptor.ImplementationType);
+    }
+
+    [Fact]
     public void ConfigureAppServices_RegistersRemotePluginServicesAsSingletons()
     {
         var services = new ServiceCollection();

--- a/AkashaNavigator.Tests/Services/PluginRepositoryGitClientTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginRepositoryGitClientTests.cs
@@ -1,0 +1,144 @@
+using System.IO;
+using AkashaNavigator.Services;
+using LibGit2Sharp;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginRepositoryGitClientTests : IDisposable
+{
+    private readonly string _testDirectory =
+        Path.Combine(Path.GetTempPath(), $"akasha-git-client-{Guid.NewGuid():N}");
+
+    [Fact]
+    public async Task SynchronizeAsync_ClonesFetchesAndSkipsUnchangedCheckout()
+    {
+        var sourceDirectory = CreateSourceRepository("first");
+        var cacheDirectory = Path.Combine(_testDirectory, "cache");
+        var client = new PluginRepositoryGitClient();
+
+        var firstCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+        var indexPath = Path.Combine(
+            cacheDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        var firstWriteTime = File.GetLastWriteTimeUtc(indexPath);
+
+        await Task.Delay(20);
+        var unchangedCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+
+        Assert.Equal(firstCommit, unchangedCommit);
+        Assert.Equal(firstWriteTime, File.GetLastWriteTimeUtc(indexPath));
+
+        var secondCommit = CommitIndex(sourceDirectory, "second");
+        var fetchedCommit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+
+        Assert.Equal(secondCommit, fetchedCommit);
+        Assert.Equal("second", File.ReadAllText(indexPath));
+        Assert.Equal(secondCommit, client.GetHeadCommit(cacheDirectory));
+    }
+
+    [Fact]
+    public async Task SynchronizeAsync_ResetRebuildsCorruptedCache()
+    {
+        var sourceDirectory = CreateSourceRepository("valid");
+        var cacheDirectory = Path.Combine(_testDirectory, "cache");
+        var client = new PluginRepositoryGitClient();
+        await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: false,
+            CancellationToken.None);
+        DeleteDirectory(Path.Combine(cacheDirectory, ".git"));
+        File.WriteAllText(
+            Path.Combine(cacheDirectory, AppConstants.PluginRepositoryIndexFileName),
+            "corrupted");
+
+        var commit = await client.SynchronizeAsync(
+            sourceDirectory,
+            AppConstants.OfficialPluginRepositoryBranch,
+            cacheDirectory,
+            reset: true,
+            CancellationToken.None);
+
+        Assert.Equal("valid", File.ReadAllText(
+            Path.Combine(cacheDirectory, AppConstants.PluginRepositoryIndexFileName)));
+        Assert.Equal(commit, client.GetHeadCommit(cacheDirectory));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            DeleteDirectory(_testDirectory);
+        }
+    }
+
+    private string CreateSourceRepository(string content)
+    {
+        var sourceDirectory = Path.Combine(_testDirectory, "source");
+        Directory.CreateDirectory(sourceDirectory);
+        Repository.Init(sourceDirectory);
+        using var repository = new Repository(sourceDirectory);
+        var indexPath = Path.Combine(
+            sourceDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        File.WriteAllText(indexPath, content);
+        Commands.Stage(repository, AppConstants.PluginRepositoryIndexFileName);
+        repository.Commit("initial", CreateSignature(), CreateSignature());
+        var catalog = repository.CreateBranch(
+            AppConstants.OfficialPluginRepositoryBranch);
+        Commands.Checkout(repository, catalog);
+        return sourceDirectory;
+    }
+
+    private static string CommitIndex(string sourceDirectory, string content)
+    {
+        using var repository = new Repository(sourceDirectory);
+        var indexPath = Path.Combine(
+            sourceDirectory,
+            AppConstants.PluginRepositoryIndexFileName);
+        File.WriteAllText(indexPath, content);
+        Commands.Stage(repository, AppConstants.PluginRepositoryIndexFileName);
+        return repository.Commit(
+            "update",
+            CreateSignature(),
+            CreateSignature()).Sha;
+    }
+
+    private static Signature CreateSignature()
+    {
+        return new Signature(
+            "Akasha Tests",
+            "tests@example.invalid",
+            DateTimeOffset.UnixEpoch);
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        foreach (var filePath in Directory.EnumerateFiles(
+                     directory,
+                     "*",
+                     SearchOption.AllDirectories))
+        {
+            File.SetAttributes(filePath, FileAttributes.Normal);
+        }
+
+        Directory.Delete(directory, recursive: true);
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginRepositoryServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginRepositoryServiceTests.cs
@@ -1,0 +1,333 @@
+using System.IO;
+using System.Text.Json;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginRepositoryServiceTests : IDisposable
+{
+    private const string SourceCommit =
+        "0123456789abcdef0123456789abcdef01234567";
+    private const string CatalogCommit =
+        "89abcdef0123456789abcdef0123456789abcdef";
+
+    private readonly string _testDirectory =
+        Path.Combine(Path.GetTempPath(), $"akasha-repository-{Guid.NewGuid():N}");
+    private readonly Mock<ILogService> _logService = new();
+
+    [Fact]
+    public async Task InitializeAsync_UsesValidCacheWithoutSynchronizing()
+    {
+        var repositoryDirectory = GetRepositoryDirectory();
+        WriteIndex(repositoryDirectory, CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.InitializeAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.UsedCache);
+        Assert.Equal(CatalogCommit, result.Value.CatalogCommit);
+        Assert.Equal(0, gitClient.SynchronizeCount);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_SynchronizesAndPublishesFreshSnapshot()
+    {
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, CreateIndex());
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.UsedCache);
+        Assert.Same(result.Value, service.Current);
+        Assert.Equal(AppConstants.OfficialPluginRepositoryGitHubUrl, gitClient.RepositoryUrl);
+        Assert.Equal(AppConstants.OfficialPluginRepositoryBranch, gitClient.Branch);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenSynchronizationFails_ReturnsCachedSnapshot()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit,
+            Synchronize = (_, _, _, _, _) =>
+                Task.FromException<string>(new IOException("network unavailable"))
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.UsedCache);
+        Assert.Equal(CatalogCommit, result.Value.CatalogCommit);
+        _logService.Verify(
+            logger => logger.Warn(
+                nameof(PluginRepositoryService),
+                It.IsAny<string>(),
+                It.IsAny<object?[]>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResetAsync_WhenSynchronizationFails_DoesNotUseCache()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit,
+            Synchronize = (_, _, _, _, _) =>
+                Task.FromException<string>(new IOException("network unavailable"))
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.ResetAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_SYNC_FAILED", result.Error!.Code);
+        Assert.True(gitClient.Reset);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RejectsDuplicateOrUnsortedPluginIds()
+    {
+        var invalidIndex = CreateIndex();
+        invalidIndex.Plugins.Add(CreateEntry("sample-plugin"));
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, invalidIndex);
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_ENTRY_INVALID", result.Error!.Code);
+        Assert.Null(service.Current);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_RejectsNullPluginCollectionWithoutThrowing()
+    {
+        var invalidIndex = CreateIndex();
+        invalidIndex.Plugins = null!;
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = (_, _, directory, _, _) =>
+        {
+            WriteIndex(directory, invalidIndex);
+            return Task.FromResult(CatalogCommit);
+        };
+        var service = CreateService(gitClient);
+
+        var result = await service.RefreshAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_INDEX_INVALID", result.Error!.Code);
+    }
+
+    [Fact]
+    public void SaveSettings_ValidatesAndPersistsRepositorySource()
+    {
+        var service = CreateService(new FakePluginRepositoryGitClient());
+        var invalidResult = service.SaveSettings(
+            new PluginRepositorySettings {
+                SelectedChannel = PluginRepositoryChannel.Custom,
+                CustomUrl = "http://example.com/plugins.git"
+            });
+
+        Assert.True(invalidResult.IsFailure);
+        Assert.Equal("PLUGIN_REPOSITORY_URL_INVALID", invalidResult.Error!.Code);
+
+        var settings = new PluginRepositorySettings {
+            SelectedChannel = PluginRepositoryChannel.Cnb,
+            AutoUpdateRepository = false,
+            AutoUpdateSubscribedPlugins = true
+        };
+        var saveResult = service.SaveSettings(settings);
+
+        Assert.True(saveResult.IsSuccess);
+        var json = File.ReadAllText(GetSettingsFilePath());
+        var persisted = JsonSerializer.Deserialize<PluginRepositorySettings>(
+            json,
+            JsonHelper.ReadOptions);
+        Assert.Equal(PluginRepositoryChannel.Cnb, persisted!.SelectedChannel);
+        Assert.False(persisted.AutoUpdateRepository);
+        Assert.True(persisted.AutoUpdateSubscribedPlugins);
+
+        settings.SelectedChannel = PluginRepositoryChannel.GitHub;
+        var returnedSettings = service.Settings;
+        returnedSettings.SelectedChannel = PluginRepositoryChannel.Custom;
+        Assert.Equal(PluginRepositoryChannel.Cnb, service.Settings.SelectedChannel);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_SerializesConcurrentRepositoryWrites()
+    {
+        WriteIndex(GetRepositoryDirectory(), CreateIndex());
+        var activeCalls = 0;
+        var maximumActiveCalls = 0;
+        var gitClient = new FakePluginRepositoryGitClient {
+            HeadCommit = CatalogCommit
+        };
+        gitClient.Synchronize = async (_, _, _, _, cancellationToken) =>
+        {
+            var active = Interlocked.Increment(ref activeCalls);
+            InterlockedExtensions.Max(ref maximumActiveCalls, active);
+            await Task.Delay(25, cancellationToken);
+            Interlocked.Decrement(ref activeCalls);
+            return CatalogCommit;
+        };
+        var service = CreateService(gitClient);
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(_ => service.RefreshAsync()));
+
+        Assert.All(results, result => Assert.True(result.IsSuccess));
+        Assert.Equal(1, maximumActiveCalls);
+        Assert.Equal(4, gitClient.SynchronizeCount);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    private PluginRepositoryService CreateService(
+        IPluginRepositoryGitClient gitClient)
+    {
+        return new PluginRepositoryService(
+            _logService.Object,
+            gitClient,
+            GetRepositoryDirectory(),
+            GetSettingsFilePath());
+    }
+
+    private string GetRepositoryDirectory()
+    {
+        return Path.Combine(_testDirectory, "repository");
+    }
+
+    private string GetSettingsFilePath()
+    {
+        return Path.Combine(_testDirectory, "plugin-repositories.json");
+    }
+
+    private static PluginRepositoryIndex CreateIndex()
+    {
+        return new PluginRepositoryIndex {
+            SchemaVersion = 1,
+            Commit = SourceCommit,
+            Plugins = new List<PluginRepositoryEntry> {
+                CreateEntry("sample-plugin")
+            }
+        };
+    }
+
+    private static PluginRepositoryEntry CreateEntry(string id)
+    {
+        return new PluginRepositoryEntry {
+            Id = id,
+            Path = $"plugins/{id}",
+            Name = "Sample Plugin",
+            Version = "1.0.0",
+            Description = "Sample description",
+            DistributionType = "repository",
+            MinHostVersion = "1.4.0"
+        };
+    }
+
+    private static void WriteIndex(
+        string repositoryDirectory,
+        PluginRepositoryIndex index)
+    {
+        var result = JsonHelper.SaveToFile(
+            Path.Combine(repositoryDirectory, AppConstants.PluginRepositoryIndexFileName),
+            index);
+        Assert.True(result.IsSuccess);
+    }
+
+    private sealed class FakePluginRepositoryGitClient : IPluginRepositoryGitClient
+    {
+        public Func<string, string, string, bool, CancellationToken, Task<string>>
+            Synchronize { get; set; } =
+                (_, _, _, _, _) => Task.FromResult(CatalogCommit);
+
+        public string? HeadCommit { get; set; }
+
+        public int SynchronizeCount { get; private set; }
+
+        public string? RepositoryUrl { get; private set; }
+
+        public string? Branch { get; private set; }
+
+        public bool Reset { get; private set; }
+
+        public Task<string> SynchronizeAsync(
+            string repositoryUrl,
+            string branch,
+            string repositoryDirectory,
+            bool reset,
+            CancellationToken cancellationToken)
+        {
+            SynchronizeCount++;
+            RepositoryUrl = repositoryUrl;
+            Branch = branch;
+            Reset = reset;
+            return Synchronize(
+                repositoryUrl,
+                branch,
+                repositoryDirectory,
+                reset,
+                cancellationToken);
+        }
+
+        public string? GetHeadCommit(string repositoryDirectory)
+        {
+            return HeadCommit;
+        }
+    }
+
+    private static class InterlockedExtensions
+    {
+        public static void Max(ref int location, int value)
+        {
+            var current = Volatile.Read(ref location);
+            while (current < value)
+            {
+                var observed = Interlocked.CompareExchange(
+                    ref location,
+                    value,
+                    current);
+                if (observed == current)
+                {
+                    return;
+                }
+
+                current = observed;
+            }
+        }
+    }
+}

--- a/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
@@ -1,0 +1,188 @@
+using System.IO;
+using AkashaNavigator.Core.Events;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Config;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using AkashaNavigator.ViewModels.Pages;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.ViewModels;
+
+public sealed class AvailablePluginsPageViewModelTests
+{
+    private const string CatalogCommit =
+        "89abcdef0123456789abcdef0123456789abcdef";
+
+    [Fact]
+    public void RefreshPluginList_UsesRepositoryIndexAsCatalogAuthority()
+    {
+        var snapshot = CreateSnapshot(usedCache: true);
+        var repositoryService = CreateRepositoryService(snapshot);
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(
+                new List<InstalledPluginInfo> {
+                    new() {
+                        Id = "alpha-plugin",
+                        Name = "Old Alpha",
+                        Version = "1.0.0"
+                    }
+                });
+        var packageService = new Mock<IPluginPackageService>();
+        var viewModel = CreateViewModel(
+            repositoryService.Object,
+            pluginLibrary.Object,
+            packageService.Object);
+
+        viewModel.RefreshPluginList();
+
+        Assert.Equal(2, viewModel.Plugins.Count);
+        var alpha = Assert.Single(
+            viewModel.Plugins.Where(plugin => plugin.Id == "alpha-plugin"));
+        Assert.Equal("2.0.0", alpha.Version);
+        Assert.True(alpha.IsInstalled);
+        Assert.True(alpha.HasUpdate);
+        Assert.Equal(
+            Path.Combine("C:\\catalog-cache", "plugins/alpha-plugin"),
+            alpha.SourceDirectory);
+        packageService.Verify(
+            service => service.GetRemoteCatalog(),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task OnLoadedAsync_ReportsCachedRepositoryAndDoesNotRefreshLegacyManifest()
+    {
+        var snapshot = CreateSnapshot(usedCache: true);
+        var repositoryService = CreateRepositoryService(snapshot);
+        repositoryService
+            .Setup(service => service.InitializeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PluginRepositorySnapshot>.Success(snapshot));
+        var viewModel = CreateViewModel(repositoryService.Object);
+
+        await viewModel.OnLoadedAsync();
+
+        Assert.Contains("本地缓存", viewModel.RepositoryStatusText);
+        Assert.Contains("2 个插件", viewModel.RepositoryStatusText);
+        repositoryService.Verify(
+            service => service.InitializeAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateRepositoryCommand_SavesChannelThenRefreshesCatalog()
+    {
+        var cached = CreateSnapshot(usedCache: true);
+        var fresh = CreateSnapshot(usedCache: false);
+        var current = cached;
+        PluginRepositorySettings? savedSettings = null;
+        var repositoryService = CreateRepositoryService(cached);
+        repositoryService
+            .SetupGet(service => service.Current)
+            .Returns(() => current);
+        repositoryService
+            .Setup(service => service.SaveSettings(
+                It.IsAny<PluginRepositorySettings>()))
+            .Callback<PluginRepositorySettings>(settings => savedSettings = settings)
+            .Returns(Result.Success());
+        repositoryService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => current = fresh)
+            .ReturnsAsync(Result<PluginRepositorySnapshot>.Success(fresh));
+        var viewModel = CreateViewModel(repositoryService.Object);
+        viewModel.SelectedRepositoryChannel = PluginRepositoryChannel.Cnb;
+        viewModel.AutoUpdateRepository = false;
+
+        await viewModel.UpdateRepositoryCommand.ExecuteAsync(null);
+
+        Assert.Equal(PluginRepositoryChannel.Cnb, savedSettings!.SelectedChannel);
+        Assert.False(savedSettings.AutoUpdateRepository);
+        Assert.Contains("最新仓库", viewModel.RepositoryStatusText);
+        repositoryService.Verify(
+            service => service.RefreshAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static AvailablePluginsPageViewModel CreateViewModel(
+        IPluginRepositoryService repositoryService,
+        IPluginLibrary? pluginLibrary = null,
+        IPluginPackageService? packageService = null)
+    {
+        var library = pluginLibrary ?? CreatePluginLibrary().Object;
+        var configService = new Mock<IConfigService>();
+        configService.SetupGet(service => service.Config).Returns(new AppConfig());
+        return new AvailablePluginsPageViewModel(
+            library,
+            Mock.Of<INotificationService>(),
+            Mock.Of<IEventBus>(),
+            repositoryService,
+            packageService ?? Mock.Of<IPluginPackageService>(),
+            configService.Object);
+    }
+
+    private static Mock<IPluginLibrary> CreatePluginLibrary()
+    {
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(new List<InstalledPluginInfo>());
+        return pluginLibrary;
+    }
+
+    private static Mock<IPluginRepositoryService> CreateRepositoryService(
+        PluginRepositorySnapshot snapshot)
+    {
+        var repositoryService = new Mock<IPluginRepositoryService>();
+        repositoryService
+            .SetupGet(service => service.RepositoryDirectory)
+            .Returns("C:\\catalog-cache");
+        repositoryService
+            .SetupGet(service => service.Current)
+            .Returns(snapshot);
+        repositoryService
+            .SetupGet(service => service.Settings)
+            .Returns(new PluginRepositorySettings());
+        repositoryService
+            .Setup(service => service.SaveSettings(
+                It.IsAny<PluginRepositorySettings>()))
+            .Returns(Result.Success());
+        return repositoryService;
+    }
+
+    private static PluginRepositorySnapshot CreateSnapshot(bool usedCache)
+    {
+        return new PluginRepositorySnapshot(
+            new PluginRepositoryIndex {
+                SchemaVersion = 1,
+                Commit = "0123456789abcdef0123456789abcdef01234567",
+                Plugins = new List<PluginRepositoryEntry> {
+                    new() {
+                        Id = "alpha-plugin",
+                        Path = "plugins/alpha-plugin",
+                        Name = "Alpha",
+                        Version = "2.0.0",
+                        Description = "Alpha description",
+                        DistributionType = AppConstants.PluginDistributionRepository,
+                        MinHostVersion = "1.4.0"
+                    },
+                    new() {
+                        Id = "beta-plugin",
+                        Path = "plugins/beta-plugin",
+                        Name = "Beta",
+                        Version = "1.0.0",
+                        Description = "Beta description",
+                        DistributionType = AppConstants.PluginDistributionRelease,
+                        HasBackend = true,
+                        MinHostVersion = "1.4.0"
+                    }
+                }
+            },
+            CatalogCommit,
+            usedCache);
+    }
+}

--- a/AkashaNavigator/AkashaNavigator.csproj
+++ b/AkashaNavigator/AkashaNavigator.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2420.47" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />

--- a/AkashaNavigator/App.xaml.cs
+++ b/AkashaNavigator/App.xaml.cs
@@ -189,12 +189,42 @@ public partial class App : System.Windows.Application
         var updateManifestService = serviceProvider.GetRequiredService<IUpdateManifestService>();
         var pluginResourceUpdateService =
             serviceProvider.GetRequiredService<IPluginResourceUpdateService>();
+        var pluginRepositoryService =
+            serviceProvider.GetRequiredService<IPluginRepositoryService>();
         var notificationService = serviceProvider.GetRequiredService<INotificationService>();
         _ = RefreshUpdateManifestInBackgroundAsync(
             updateManifestService,
             pluginResourceUpdateService,
             notificationService,
             logService);
+        _ = RefreshPluginRepositoryInBackgroundAsync(
+            pluginRepositoryService,
+            logService);
+    }
+
+    private static async Task RefreshPluginRepositoryInBackgroundAsync(
+        IPluginRepositoryService pluginRepositoryService,
+        ILogService logService)
+    {
+        if (!pluginRepositoryService.Settings.AutoUpdateRepository)
+        {
+            return;
+        }
+
+        var result = await pluginRepositoryService.RefreshAsync();
+        if (result.IsFailure)
+        {
+            logService.Warn(
+                nameof(App),
+                "后台更新插件仓库失败: {ErrorMessage}",
+                result.Error?.Message ?? "未知错误");
+        }
+        else if (result.Value!.UsedCache)
+        {
+            logService.Warn(
+                nameof(App),
+                "后台更新插件仓库失败，继续使用本地缓存");
+        }
     }
 
     private static async Task RefreshUpdateManifestInBackgroundAsync(

--- a/AkashaNavigator/AppConstants.cs
+++ b/AkashaNavigator/AppConstants.cs
@@ -241,6 +241,16 @@ public static class AppConstants
     public const string PluginManifestFileName = "plugin.json";
 
     /// <summary>
+    /// 插件仓库索引文件名。
+    /// </summary>
+    public const string PluginRepositoryIndexFileName = "repo.json";
+
+    /// <summary>
+    /// 插件仓库配置文件名。
+    /// </summary>
+    public const string PluginRepositoriesConfigFileName = "plugin-repositories.json";
+
+    /// <summary>
     /// 插件配置文件名
     /// </summary>
     public const string PluginConfigFileName = "config.json";
@@ -258,6 +268,32 @@ public static class AppConstants
     /// Akasha Automation 插件 ID。
     /// </summary>
     public const string AutomationPluginId = "akasha-genshin-automation";
+
+    /// <summary>
+    /// 官方插件仓库 ID。
+    /// </summary>
+    public const string OfficialPluginRepositoryId = "official";
+
+    /// <summary>
+    /// 官方插件仓库默认分支。
+    /// </summary>
+    public const string OfficialPluginRepositoryBranch = "catalog";
+
+    /// <summary>
+    /// 官方插件仓库 GitHub 地址。
+    /// </summary>
+    public const string OfficialPluginRepositoryGitHubUrl =
+        "https://github.com/ColinXHL/akasha-plugins.git";
+
+    /// <summary>
+    /// 官方插件仓库 CNB 地址。
+    /// </summary>
+    public const string OfficialPluginRepositoryCnbUrl =
+        "https://cnb.cool/AkashaNavigator/akasha-plugins.git";
+
+    public const string PluginDistributionRepository = "repository";
+
+    public const string PluginDistributionRelease = "release";
 
     /// <summary>
     /// Notice 中拾取黑名单资源的键。

--- a/AkashaNavigator/Core/Interfaces/IPluginRepositoryService.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginRepositoryService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+/// <summary>
+/// 管理官方插件仓库只读缓存和 repo.json。
+/// </summary>
+public interface IPluginRepositoryService
+{
+    string RepositoryDirectory { get; }
+
+    PluginRepositorySnapshot? Current { get; }
+
+    PluginRepositorySettings Settings { get; }
+
+    Task<Result<PluginRepositorySnapshot>> InitializeAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<Result<PluginRepositorySnapshot>> RefreshAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<Result<PluginRepositorySnapshot>> ResetAsync(
+        CancellationToken cancellationToken = default);
+
+    Result SaveSettings(PluginRepositorySettings settings);
+}

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -81,6 +81,9 @@ public static class ServiceCollectionExtensions
         // ConfigService（依赖LogService）
         services.AddSingleton<IConfigService, ConfigService>();
 
+        // PluginRepositoryService（官方 catalog 缓存与索引）
+        services.AddSingleton<IPluginRepositoryService, PluginRepositoryService>();
+
         // ShutdownCoordinator（依赖 LogService，统一编排幂等关停阶段）
         services.AddSingleton<ShutdownCoordinator>();
 

--- a/AkashaNavigator/Helpers/AppPaths.cs
+++ b/AkashaNavigator/Helpers/AppPaths.cs
@@ -112,6 +112,21 @@ public static class AppPaths
     /// </summary>
     public static string PluginResourcesDirectory { get; }
 
+    /// <summary>
+    /// 插件仓库只读缓存根目录（User/Data/PluginRepositories/）。
+    /// </summary>
+    public static string PluginRepositoriesDirectory { get; }
+
+    /// <summary>
+    /// 官方插件仓库缓存目录。
+    /// </summary>
+    public static string OfficialPluginRepositoryDirectory { get; }
+
+    /// <summary>
+    /// 插件仓库配置文件。
+    /// </summary>
+    public static string PluginRepositoriesConfigFilePath { get; }
+
     static AppPaths()
     {
         // 获取应用程序目录
@@ -161,6 +176,11 @@ public static class AppPaths
         NoticeCacheFilePath = Path.Combine(UpdateDirectory, "notice-cache.json");
         NoticeStateFilePath = Path.Combine(UpdateDirectory, "notice-state.json");
         PluginResourcesDirectory = Path.Combine(DataDirectory, "PluginResources");
+        PluginRepositoriesDirectory = Path.Combine(DataDirectory, "PluginRepositories");
+        OfficialPluginRepositoryDirectory =
+            Path.Combine(PluginRepositoriesDirectory, AppConstants.OfficialPluginRepositoryId);
+        PluginRepositoriesConfigFilePath =
+            Path.Combine(DataDirectory, AppConstants.PluginRepositoriesConfigFileName);
 
         // 确保目录存在
         EnsureDirectoriesExist();
@@ -203,6 +223,7 @@ public static class AppPaths
         Directory.CreateDirectory(InstalledPluginsDirectory);
         Directory.CreateDirectory(UpdateDirectory);
         Directory.CreateDirectory(PluginResourcesDirectory);
+        Directory.CreateDirectory(PluginRepositoriesDirectory);
 
         // 为 WebView2 数据文件夹设置写权限
         EnsureWebView2FolderPermissions();

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositoryChannel.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositoryChannel.cs
@@ -1,0 +1,11 @@
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// 官方逻辑插件仓库的网络渠道。
+/// </summary>
+public enum PluginRepositoryChannel
+{
+    GitHub,
+    Cnb,
+    Custom
+}

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositoryIndex.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositoryIndex.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// catalog 分支根目录 repo.json。
+/// </summary>
+public sealed class PluginRepositoryIndex
+{
+    public int SchemaVersion { get; set; }
+
+    /// <summary>
+    /// 生成 catalog 的 main 源提交。
+    /// </summary>
+    public string Commit { get; set; } = string.Empty;
+
+    public List<PluginRepositoryEntry> Plugins { get; set; } = new();
+}
+
+/// <summary>
+/// repo.json 中的插件摘要。
+/// </summary>
+public sealed class PluginRepositoryEntry
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Path { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public string DistributionType { get; set; } = string.Empty;
+
+    public bool HasBackend { get; set; }
+
+    public string MinHostVersion { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 一次仓库读取或同步后的不可变快照。
+/// </summary>
+public sealed record PluginRepositorySnapshot(
+    PluginRepositoryIndex Index,
+    string CatalogCommit,
+    bool UsedCache);

--- a/AkashaNavigator/Models/PluginRepository/PluginRepositorySettings.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginRepositorySettings.cs
@@ -1,0 +1,30 @@
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// 官方插件仓库的本地配置。
+/// </summary>
+public sealed class PluginRepositorySettings
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public PluginRepositoryChannel SelectedChannel { get; set; } =
+        PluginRepositoryChannel.GitHub;
+
+    public string CustomUrl { get; set; } = string.Empty;
+
+    public string Branch { get; set; } = AppConstants.OfficialPluginRepositoryBranch;
+
+    public bool AutoUpdateRepository { get; set; } = true;
+
+    public bool AutoUpdateSubscribedPlugins { get; set; }
+
+    public string GetSelectedUrl()
+    {
+        return SelectedChannel switch {
+            PluginRepositoryChannel.GitHub => AppConstants.OfficialPluginRepositoryGitHubUrl,
+            PluginRepositoryChannel.Cnb => AppConstants.OfficialPluginRepositoryCnbUrl,
+            PluginRepositoryChannel.Custom => CustomUrl ?? string.Empty,
+            _ => string.Empty
+        };
+    }
+}

--- a/AkashaNavigator/Services/PluginRepositoryGitClient.cs
+++ b/AkashaNavigator/Services/PluginRepositoryGitClient.cs
@@ -1,0 +1,197 @@
+using System.IO;
+using LibGit2Sharp;
+
+namespace AkashaNavigator.Services;
+
+internal interface IPluginRepositoryGitClient
+{
+    Task<string> SynchronizeAsync(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken);
+
+    string? GetHeadCommit(string repositoryDirectory);
+}
+
+internal sealed class PluginRepositoryGitClient : IPluginRepositoryGitClient
+{
+    public Task<string> SynchronizeAsync(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () =>
+            {
+                try
+                {
+                    return Synchronize(
+                        repositoryUrl,
+                        branch,
+                        repositoryDirectory,
+                        reset,
+                        cancellationToken);
+                }
+                catch (UserCancelledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+            },
+            cancellationToken);
+    }
+
+    public string? GetHeadCommit(string repositoryDirectory)
+    {
+        if (!Repository.IsValid(repositoryDirectory))
+        {
+            return null;
+        }
+
+        using var repository = new Repository(repositoryDirectory);
+        return repository.Head.Tip?.Sha;
+    }
+
+    private static string Synchronize(
+        string repositoryUrl,
+        string branch,
+        string repositoryDirectory,
+        bool reset,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (reset && Directory.Exists(repositoryDirectory))
+        {
+            DeleteRepositoryCache(repositoryDirectory);
+        }
+
+        if (!Repository.IsValid(repositoryDirectory))
+        {
+            if (Directory.Exists(repositoryDirectory))
+            {
+                DeleteRepositoryCache(repositoryDirectory);
+            }
+
+            var cloneOptions = new CloneOptions(CreateFetchOptions(cancellationToken)) {
+                BranchName = branch,
+                Checkout = true,
+                RecurseSubmodules = false
+            };
+            Repository.Clone(repositoryUrl, repositoryDirectory, cloneOptions);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var cloned = new Repository(repositoryDirectory);
+            return cloned.Head.Tip?.Sha
+                   ?? throw new InvalidDataException("克隆后的 catalog 分支没有提交");
+        }
+
+        using var repository = new Repository(repositoryDirectory);
+        var remote = repository.Network.Remotes["origin"]
+                     ?? throw new InvalidDataException("插件仓库缺少 origin 远端");
+        if (!string.Equals(remote.Url, repositoryUrl, StringComparison.Ordinal))
+        {
+            repository.Network.Remotes.Update(
+                remote.Name,
+                update => update.Url = repositoryUrl);
+            remote = repository.Network.Remotes["origin"]!;
+        }
+
+        Commands.Fetch(
+            repository,
+            remote.Name,
+            new[] { $"+refs/heads/{branch}:refs/remotes/{remote.Name}/{branch}" },
+            CreateFetchOptions(cancellationToken),
+            null);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var remoteBranch = repository.Branches[$"{remote.Name}/{branch}"]
+                           ?? throw new InvalidDataException($"远端分支不存在: {branch}");
+        if (string.Equals(
+                repository.Head.FriendlyName,
+                branch,
+                StringComparison.Ordinal) &&
+            string.Equals(
+                repository.Head.Tip?.Sha,
+                remoteBranch.Tip.Sha,
+                StringComparison.Ordinal) &&
+            !repository.RetrieveStatus().IsDirty)
+        {
+            return remoteBranch.Tip.Sha;
+        }
+
+        var localBranch = repository.Branches[branch]
+                          ?? repository.CreateBranch(branch, remoteBranch.Tip);
+        Commands.Checkout(
+            repository,
+            localBranch,
+            new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+        repository.Reset(ResetMode.Hard, remoteBranch.Tip);
+        repository.Branches.Update(
+            localBranch,
+            update => update.TrackedBranch = remoteBranch.CanonicalName);
+
+        return remoteBranch.Tip.Sha;
+    }
+
+    private static FetchOptions CreateFetchOptions(
+        CancellationToken cancellationToken)
+    {
+        return new FetchOptions {
+            OnProgress = _ => !cancellationToken.IsCancellationRequested,
+            OnTransferProgress = _ => !cancellationToken.IsCancellationRequested
+        };
+    }
+
+    private static void DeleteRepositoryCache(string repositoryDirectory)
+    {
+        var fullPath = Path.TrimEndingDirectorySeparator(
+            Path.GetFullPath(repositoryDirectory));
+        var rootPath = Path.TrimEndingDirectorySeparator(
+            Path.GetPathRoot(fullPath) ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(Path.GetFileName(fullPath)) ||
+            string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("拒绝删除无效的插件仓库缓存路径");
+        }
+
+        DeleteDirectoryTree(fullPath);
+    }
+
+    private static void DeleteDirectoryTree(string directory)
+    {
+        foreach (var entryPath in Directory.EnumerateFileSystemEntries(directory))
+        {
+            var attributes = File.GetAttributes(entryPath);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                File.SetAttributes(entryPath, FileAttributes.Normal);
+                if ((attributes & FileAttributes.Directory) != 0)
+                {
+                    Directory.Delete(entryPath);
+                }
+                else
+                {
+                    File.Delete(entryPath);
+                }
+
+                continue;
+            }
+
+            if ((attributes & FileAttributes.Directory) != 0)
+            {
+                DeleteDirectoryTree(entryPath);
+                continue;
+            }
+
+            File.SetAttributes(entryPath, attributes & ~FileAttributes.ReadOnly);
+            File.Delete(entryPath);
+        }
+
+        File.SetAttributes(directory, FileAttributes.Normal);
+        Directory.Delete(directory);
+    }
+}

--- a/AkashaNavigator/Services/PluginRepositoryService.cs
+++ b/AkashaNavigator/Services/PluginRepositoryService.cs
@@ -1,0 +1,364 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 官方插件仓库缓存服务。
+/// </summary>
+public sealed class PluginRepositoryService : IPluginRepositoryService
+{
+    private readonly ILogService _logService;
+    private readonly IPluginRepositoryGitClient _gitClient;
+    private readonly string _repositoryDirectory;
+    private readonly string _settingsFilePath;
+    private readonly object _settingsLock = new();
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    private PluginRepositorySnapshot? _current;
+    private PluginRepositorySettings _settings;
+
+    public PluginRepositoryService(ILogService logService)
+        : this(
+            logService,
+            new PluginRepositoryGitClient(),
+            AppPaths.OfficialPluginRepositoryDirectory,
+            AppPaths.PluginRepositoriesConfigFilePath)
+    {
+    }
+
+    internal PluginRepositoryService(
+        ILogService logService,
+        IPluginRepositoryGitClient gitClient,
+        string repositoryDirectory,
+        string settingsFilePath)
+    {
+        _logService = logService ?? throw new ArgumentNullException(nameof(logService));
+        _gitClient = gitClient ?? throw new ArgumentNullException(nameof(gitClient));
+        _repositoryDirectory =
+            repositoryDirectory ?? throw new ArgumentNullException(nameof(repositoryDirectory));
+        _settingsFilePath =
+            settingsFilePath ?? throw new ArgumentNullException(nameof(settingsFilePath));
+        _settings = LoadSettings();
+        _current = LoadSnapshot(usedCache: true).Value;
+    }
+
+    public PluginRepositorySnapshot? Current => Volatile.Read(ref _current);
+
+    public string RepositoryDirectory => _repositoryDirectory;
+
+    public PluginRepositorySettings Settings
+    {
+        get
+        {
+            lock (_settingsLock)
+            {
+                return CloneSettings(_settings);
+            }
+        }
+    }
+
+    public async Task<Result<PluginRepositorySnapshot>> InitializeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var cached = Current;
+        if (cached != null)
+        {
+            return Result<PluginRepositorySnapshot>.Success(cached);
+        }
+
+        return await RefreshCoreAsync(reset: false, allowCacheFallback: false, cancellationToken);
+    }
+
+    public Task<Result<PluginRepositorySnapshot>> RefreshAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return RefreshCoreAsync(reset: false, allowCacheFallback: true, cancellationToken);
+    }
+
+    public Task<Result<PluginRepositorySnapshot>> ResetAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return RefreshCoreAsync(reset: true, allowCacheFallback: false, cancellationToken);
+    }
+
+    public Result SaveSettings(PluginRepositorySettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        var validation = ValidateSettings(settings);
+        if (validation != null)
+        {
+            return Result.Failure(validation);
+        }
+
+        lock (_settingsLock)
+        {
+            var saveResult = JsonHelper.SaveToFile(_settingsFilePath, settings);
+            if (saveResult.IsFailure)
+            {
+                return saveResult;
+            }
+
+            _settings = CloneSettings(settings);
+        }
+
+        return Result.Success();
+    }
+
+    private async Task<Result<PluginRepositorySnapshot>> RefreshCoreAsync(
+        bool reset,
+        bool allowCacheFallback,
+        CancellationToken cancellationToken)
+    {
+        var lockTaken = false;
+        var settings = Settings;
+        try
+        {
+            await _writeLock.WaitAsync(cancellationToken);
+            lockTaken = true;
+
+            settings = Settings;
+            var validation = ValidateSettings(settings);
+            if (validation != null)
+            {
+                return UseCacheOrFailure(validation, allowCacheFallback);
+            }
+
+            var repositoryUrl = settings.GetSelectedUrl();
+            await _gitClient.SynchronizeAsync(
+                repositoryUrl,
+                settings.Branch,
+                _repositoryDirectory,
+                reset,
+                cancellationToken);
+
+            var snapshotResult = LoadSnapshot(usedCache: false);
+            if (snapshotResult.IsFailure)
+            {
+                return UseCacheOrFailure(snapshotResult.Error!, allowCacheFallback);
+            }
+
+            Volatile.Write(ref _current, snapshotResult.Value);
+            return snapshotResult;
+        }
+        catch (OperationCanceledException ex)
+        {
+            return UseCacheOrFailure(
+                Error.Network(
+                    "PLUGIN_REPOSITORY_SYNC_CANCELED",
+                    "插件仓库同步已取消",
+                    ex,
+                    settings.GetSelectedUrl()),
+                allowCacheFallback);
+        }
+        catch (Exception ex)
+        {
+            return UseCacheOrFailure(
+                Error.Network(
+                    "PLUGIN_REPOSITORY_SYNC_FAILED",
+                    ex.Message,
+                    ex,
+                    settings.GetSelectedUrl()),
+                allowCacheFallback);
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                _writeLock.Release();
+            }
+        }
+    }
+
+    private Result<PluginRepositorySnapshot> LoadSnapshot(bool usedCache)
+    {
+        try
+        {
+            var indexPath = Path.Combine(
+                _repositoryDirectory,
+                AppConstants.PluginRepositoryIndexFileName);
+            var loadResult = JsonHelper.LoadFromFile<PluginRepositoryIndex>(indexPath);
+            if (loadResult.IsFailure)
+            {
+                return Result<PluginRepositorySnapshot>.Failure(loadResult.Error!);
+            }
+
+            var validation = ValidateIndex(loadResult.Value!);
+            if (validation != null)
+            {
+                return Result<PluginRepositorySnapshot>.Failure(validation);
+            }
+
+            var catalogCommit = _gitClient.GetHeadCommit(_repositoryDirectory);
+            if (!IsCommitSha(catalogCommit))
+            {
+                return Result<PluginRepositorySnapshot>.Failure(
+                    Error.FileSystem(
+                        "PLUGIN_REPOSITORY_HEAD_MISSING",
+                        "插件仓库缓存没有有效的 catalog HEAD",
+                        filePath: _repositoryDirectory));
+            }
+
+            return Result<PluginRepositorySnapshot>.Success(
+                new PluginRepositorySnapshot(loadResult.Value!, catalogCommit!, usedCache));
+        }
+        catch (Exception ex)
+        {
+            return Result<PluginRepositorySnapshot>.Failure(
+                Error.FileSystem(
+                    "PLUGIN_REPOSITORY_CACHE_INVALID",
+                    $"读取插件仓库缓存失败: {ex.Message}",
+                    ex,
+                    _repositoryDirectory));
+        }
+    }
+
+    private Result<PluginRepositorySnapshot> UseCacheOrFailure(
+        Error error,
+        bool allowCacheFallback)
+    {
+        var cached = Current;
+        if (!allowCacheFallback || cached == null)
+        {
+            return Result<PluginRepositorySnapshot>.Failure(error);
+        }
+
+        _logService.Warn(
+            nameof(PluginRepositoryService),
+            "插件仓库同步失败，继续使用本地缓存: {ErrorMessage}",
+            error.Message);
+        return Result<PluginRepositorySnapshot>.Success(
+            cached with { UsedCache = true });
+    }
+
+    private PluginRepositorySettings LoadSettings()
+    {
+        var result = JsonHelper.LoadFromFile<PluginRepositorySettings>(_settingsFilePath);
+        if (result.IsSuccess && ValidateSettings(result.Value!) == null)
+        {
+            return result.Value!;
+        }
+
+        return new PluginRepositorySettings();
+    }
+
+    private static Error? ValidateSettings(PluginRepositorySettings settings)
+    {
+        if (settings.SchemaVersion != 1)
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_SETTINGS_VERSION_INVALID",
+                $"不支持的插件仓库配置版本: {settings.SchemaVersion}");
+        }
+
+        if (!Enum.IsDefined(settings.SelectedChannel))
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_CHANNEL_INVALID",
+                $"不支持的插件仓库渠道: {settings.SelectedChannel}");
+        }
+
+        if (!string.Equals(
+                settings.Branch,
+                AppConstants.OfficialPluginRepositoryBranch,
+                StringComparison.Ordinal))
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_BRANCH_INVALID",
+                $"官方插件仓库分支必须是 {AppConstants.OfficialPluginRepositoryBranch}");
+        }
+
+        var url = settings.GetSelectedUrl();
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return Error.Configuration(
+                "PLUGIN_REPOSITORY_URL_INVALID",
+                "插件仓库地址必须是有效的 HTTPS URL");
+        }
+
+        return null;
+    }
+
+    private static Error? ValidateIndex(PluginRepositoryIndex index)
+    {
+        if (index.SchemaVersion != 1 ||
+            !IsCommitSha(index.Commit) ||
+            index.Plugins == null)
+        {
+            return Error.Serialization(
+                "PLUGIN_REPOSITORY_INDEX_INVALID",
+                "repo.json schemaVersion 或源提交无效");
+        }
+
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? previousId = null;
+        foreach (var plugin in index.Plugins)
+        {
+            if (plugin == null)
+            {
+                return Error.Serialization(
+                    "PLUGIN_REPOSITORY_ENTRY_INVALID",
+                    "repo.json 包含 null 插件条目");
+            }
+
+            if (!PluginIdValidator.IsValid(plugin.Id) ||
+                !seenIds.Add(plugin.Id) ||
+                !string.Equals(
+                    plugin.Path,
+                    $"{AppConstants.PluginsDirectoryName}/{plugin.Id}",
+                    StringComparison.Ordinal) ||
+                string.IsNullOrWhiteSpace(plugin.Name) ||
+                !IsSemanticVersion(plugin.Version) ||
+                string.IsNullOrWhiteSpace(plugin.Description) ||
+                (plugin.DistributionType != AppConstants.PluginDistributionRepository &&
+                 plugin.DistributionType != AppConstants.PluginDistributionRelease) ||
+                !IsSemanticVersion(plugin.MinHostVersion) ||
+                (previousId != null &&
+                 string.CompareOrdinal(previousId, plugin.Id) >= 0))
+            {
+                return Error.Serialization(
+                    "PLUGIN_REPOSITORY_ENTRY_INVALID",
+                    $"repo.json 包含无效或未稳定排序的插件条目: {plugin.Id}");
+            }
+
+            previousId = plugin.Id;
+        }
+
+        return null;
+    }
+
+    private static bool IsCommitSha(string? value)
+    {
+        return value != null &&
+               value.Length is 40 or 64 &&
+               Regex.IsMatch(value, "^[0-9a-f]+$", RegexOptions.CultureInvariant);
+    }
+
+    private static bool IsSemanticVersion(string? value)
+    {
+        return value != null &&
+               Regex.IsMatch(
+                   value,
+                   "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+                   RegexOptions.CultureInvariant);
+    }
+
+    private static PluginRepositorySettings CloneSettings(
+        PluginRepositorySettings settings)
+    {
+        return new PluginRepositorySettings {
+            SchemaVersion = settings.SchemaVersion,
+            SelectedChannel = settings.SelectedChannel,
+            CustomUrl = settings.CustomUrl ?? string.Empty,
+            Branch = settings.Branch ?? string.Empty,
+            AutoUpdateRepository = settings.AutoUpdateRepository,
+            AutoUpdateSubscribedPlugins = settings.AutoUpdateSubscribedPlugins
+        };
+    }
+}

--- a/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
@@ -13,6 +13,7 @@ using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Models.Config;
 using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
 using AkashaNavigator.Models.Update;
 using AkashaNavigator.Helpers;
 using AkashaNavigator.Services;
@@ -28,7 +29,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     private readonly IPluginLibrary _pluginLibrary;
     private readonly INotificationService _notificationService;
     private readonly IEventBus _eventBus;
-    private readonly IUpdateManifestService _updateManifestService;
+    private readonly IPluginRepositoryService _pluginRepositoryService;
     private readonly IPluginPackageService _pluginPackageService;
     private readonly IConfigService _configService;
     private readonly Dictionary<string, CancellationTokenSource> _downloads =
@@ -59,6 +60,27 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     [ObservableProperty]
     private bool _isEmpty;
 
+    [ObservableProperty]
+    private PluginRepositoryChannel _selectedRepositoryChannel;
+
+    [ObservableProperty]
+    private string _customRepositoryUrl = string.Empty;
+
+    [ObservableProperty]
+    private bool _autoUpdateRepository;
+
+    [ObservableProperty]
+    private bool _autoUpdateSubscribedPlugins;
+
+    [ObservableProperty]
+    private bool _isRepositoryBusy;
+
+    [ObservableProperty]
+    private string _repositoryStatusText = "尚未加载插件仓库";
+
+    public bool IsCustomRepositoryChannel =>
+        SelectedRepositoryChannel == PluginRepositoryChannel.Custom;
+
     /// <summary>
     /// 构造函数
     /// </summary>
@@ -66,18 +88,21 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         IPluginLibrary pluginLibrary,
         INotificationService notificationService,
         IEventBus eventBus,
-        IUpdateManifestService updateManifestService,
+        IPluginRepositoryService pluginRepositoryService,
         IPluginPackageService pluginPackageService,
         IConfigService configService)
     {
         _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
-        _updateManifestService =
-            updateManifestService ?? throw new ArgumentNullException(nameof(updateManifestService));
+        _pluginRepositoryService =
+            pluginRepositoryService ?? throw new ArgumentNullException(nameof(pluginRepositoryService));
         _pluginPackageService =
             pluginPackageService ?? throw new ArgumentNullException(nameof(pluginPackageService));
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
+
+        LoadRepositorySettings();
+        UpdateRepositoryStatus(_pluginRepositoryService.Current);
 
         // 订阅插件列表变化事件
         _eventBus.Subscribe<PluginListChangedEvent>(OnPluginListChanged);
@@ -99,11 +124,18 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     {
         RefreshPluginList();
 
-        var refreshResult = await _updateManifestService.RefreshAsync();
-        if (refreshResult.IsSuccess)
+        var initializeResult = await _pluginRepositoryService.InitializeAsync();
+        if (initializeResult.IsSuccess)
         {
+            UpdateRepositoryStatus(initializeResult.Value);
             RefreshPluginList();
+            return;
         }
+
+        RepositoryStatusText = "插件仓库不可用";
+        _notificationService.Show(
+            $"加载插件仓库失败: {initializeResult.Error?.Message}",
+            NotificationType.Error);
     }
 
     /// <summary>
@@ -149,44 +181,74 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     /// </summary>
     private List<AvailablePluginItemModel> GetAllCatalogPlugins()
     {
-        var catalog = new Dictionary<string, PluginCatalogEntry>(StringComparer.OrdinalIgnoreCase);
         var installed = _pluginLibrary.GetInstalledPlugins()
             .ToDictionary(plugin => plugin.Id, StringComparer.OrdinalIgnoreCase);
-
-        // 扫描内置插件目录
-        var builtinPluginsDir = AppPaths.BuiltInPluginsDirectory;
-        if (Directory.Exists(builtinPluginsDir))
+        var snapshot = _pluginRepositoryService.Current;
+        if (snapshot == null)
         {
-            foreach (var pluginDir in Directory.GetDirectories(builtinPluginsDir))
-            {
-                var manifestPath = Path.Combine(pluginDir, "plugin.json");
-                if (!File.Exists(manifestPath))
-                    continue;
-
-                var manifest = JsonHelper.LoadFromFile<PluginManifest>(manifestPath);
-                if (manifest.IsFailure || string.IsNullOrEmpty(manifest.Value!.Id))
-                    continue;
-
-                catalog[manifest.Value.Id] = new PluginCatalogEntry {
-                    Id = manifest.Value.Id,
-                    Name = manifest.Value.Name ?? manifest.Value.Id,
-                    Version = manifest.Value.Version ?? "1.0.0",
-                    Description = manifest.Value.Description,
-                    Author = manifest.Value.Author,
-                    LocalSourceDirectory = pluginDir
-                };
-            }
+            return new List<AvailablePluginItemModel>();
         }
 
-        foreach (var remote in _pluginPackageService.GetRemoteCatalog())
-        {
-            catalog[remote.Id] = remote;
-        }
-
-        return catalog.Values
-            .Select(entry => CreateItem(entry, installed.GetValueOrDefault(entry.Id)))
+        return snapshot.Index.Plugins
+            .Select(
+                entry => CreateItem(
+                    CreateCatalogEntry(entry),
+                    installed.GetValueOrDefault(entry.Id)))
             .OrderBy(item => item.Name, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
+    }
+
+    [RelayCommand]
+    private void SaveRepositorySettings()
+    {
+        var result = TrySaveRepositorySettings();
+        _notificationService.Show(
+            result.IsSuccess
+                ? "插件仓库设置已保存"
+                : $"保存插件仓库设置失败: {result.Error?.Message}",
+            result.IsSuccess ? NotificationType.Success : NotificationType.Error);
+    }
+
+    [RelayCommand]
+    private async Task UpdateRepositoryAsync()
+    {
+        if (!CanStartRepositoryOperation())
+        {
+            return;
+        }
+
+        IsRepositoryBusy = true;
+        RepositoryStatusText = "正在更新插件仓库…";
+        try
+        {
+            var result = await _pluginRepositoryService.RefreshAsync();
+            HandleRepositoryUpdateResult(result, "插件仓库已更新");
+        }
+        finally
+        {
+            IsRepositoryBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ResetRepositoryAsync()
+    {
+        if (!CanStartRepositoryOperation())
+        {
+            return;
+        }
+
+        IsRepositoryBusy = true;
+        RepositoryStatusText = "正在重置插件仓库…";
+        try
+        {
+            var result = await _pluginRepositoryService.ResetAsync();
+            HandleRepositoryUpdateResult(result, "插件仓库已重置");
+        }
+        finally
+        {
+            IsRepositoryBusy = false;
+        }
     }
 
     /// <summary>
@@ -311,6 +373,105 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             SelectedSourceText = entry.IsRemote
                 ? $"下载源：{GetPreferenceDisplayName(_configService.Config.PluginDownloadSourcePreference)}"
                 : string.Empty
+        };
+    }
+
+    partial void OnSelectedRepositoryChannelChanged(PluginRepositoryChannel value)
+    {
+        OnPropertyChanged(nameof(IsCustomRepositoryChannel));
+    }
+
+    private void LoadRepositorySettings()
+    {
+        var settings = _pluginRepositoryService.Settings;
+        SelectedRepositoryChannel = settings.SelectedChannel;
+        CustomRepositoryUrl = settings.CustomUrl;
+        AutoUpdateRepository = settings.AutoUpdateRepository;
+        AutoUpdateSubscribedPlugins = settings.AutoUpdateSubscribedPlugins;
+    }
+
+    private Result TrySaveRepositorySettings()
+    {
+        return _pluginRepositoryService.SaveSettings(
+            new PluginRepositorySettings {
+                SelectedChannel = SelectedRepositoryChannel,
+                CustomUrl = CustomRepositoryUrl.Trim(),
+                Branch = AppConstants.OfficialPluginRepositoryBranch,
+                AutoUpdateRepository = AutoUpdateRepository,
+                AutoUpdateSubscribedPlugins = AutoUpdateSubscribedPlugins
+            });
+    }
+
+    private bool CanStartRepositoryOperation()
+    {
+        if (IsRepositoryBusy)
+        {
+            return false;
+        }
+
+        var saveResult = TrySaveRepositorySettings();
+        if (saveResult.IsSuccess)
+        {
+            return true;
+        }
+
+        _notificationService.Show(
+            $"插件仓库设置无效: {saveResult.Error?.Message}",
+            NotificationType.Error);
+        return false;
+    }
+
+    private void HandleRepositoryUpdateResult(
+        Result<PluginRepositorySnapshot> result,
+        string successMessage)
+    {
+        if (result.IsFailure)
+        {
+            RepositoryStatusText = "插件仓库更新失败";
+            _notificationService.Show(
+                $"{RepositoryStatusText}: {result.Error?.Message}",
+                NotificationType.Error);
+            return;
+        }
+
+        UpdateRepositoryStatus(result.Value);
+        RefreshPluginList();
+        _notificationService.Show(
+            result.Value!.UsedCache
+                ? "仓库更新失败，已继续使用本地缓存"
+                : successMessage,
+            result.Value.UsedCache ? NotificationType.Warning : NotificationType.Success);
+    }
+
+    private void UpdateRepositoryStatus(PluginRepositorySnapshot? snapshot)
+    {
+        if (snapshot == null)
+        {
+            RepositoryStatusText = "尚未加载插件仓库";
+            return;
+        }
+
+        var shortCommit = snapshot.CatalogCommit.Length > 8
+            ? snapshot.CatalogCommit[..8]
+            : snapshot.CatalogCommit;
+        RepositoryStatusText =
+            $"{(snapshot.UsedCache ? "本地缓存" : "最新仓库")} · {snapshot.Index.Plugins.Count} 个插件 · {shortCommit}";
+    }
+
+    private PluginCatalogEntry CreateCatalogEntry(PluginRepositoryEntry entry)
+    {
+        var isRelease =
+            entry.DistributionType == AppConstants.PluginDistributionRelease;
+        return new PluginCatalogEntry {
+            Id = entry.Id,
+            Name = entry.Name,
+            Version = entry.Version,
+            Description = entry.Description,
+            MinHostVersion = entry.MinHostVersion,
+            LocalSourceDirectory = isRelease
+                ? null
+                : Path.Combine(_pluginRepositoryService.RepositoryDirectory, entry.Path),
+            IsRemote = isRelease
         };
     }
 

--- a/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
+++ b/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:AkashaNavigator.ViewModels.Pages"
+             xmlns:repository="clr-namespace:AkashaNavigator.Models.PluginRepository"
              Background="Transparent"
              Cursor="Arrow">
 
@@ -12,6 +13,7 @@
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -35,13 +37,44 @@
                      Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
 
+        <!-- 仓库设置 -->
+        <WrapPanel Grid.Row="1" Margin="0,0,0,12" VerticalAlignment="Center">
+            <ComboBox Width="105" Margin="0,0,8,0"
+                      SelectedValuePath="Tag"
+                      SelectedValue="{Binding SelectedRepositoryChannel}">
+                <ComboBoxItem Content="GitHub"
+                              Tag="{x:Static repository:PluginRepositoryChannel.GitHub}"/>
+                <ComboBoxItem Content="CNB"
+                              Tag="{x:Static repository:PluginRepositoryChannel.Cnb}"/>
+                <ComboBoxItem Content="自定义"
+                              Tag="{x:Static repository:PluginRepositoryChannel.Custom}"/>
+            </ComboBox>
+            <TextBox Width="250" Margin="0,0,8,0"
+                     Text="{Binding CustomRepositoryUrl, UpdateSourceTrigger=PropertyChanged}"
+                     ToolTip="自定义仓库 HTTPS Git 地址"
+                     Visibility="{Binding IsCustomRepositoryChannel, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            <CheckBox Content="启动时更新仓库" Margin="0,0,12,0"
+                      Foreground="#CCC" VerticalAlignment="Center"
+                      IsChecked="{Binding AutoUpdateRepository}"/>
+            <Button Content="保存" Style="{StaticResource ActionButtonStyle}"
+                    Margin="0,0,8,0"
+                    Command="{Binding SaveRepositorySettingsCommand}"/>
+            <Button Content="更新仓库" Style="{StaticResource PrimaryActionButtonStyle}"
+                    Margin="0,0,8,0"
+                    Command="{Binding UpdateRepositoryCommand}"/>
+            <Button Content="重置仓库" Style="{StaticResource ActionButtonStyle}"
+                    Command="{Binding ResetRepositoryCommand}"/>
+        </WrapPanel>
+
         <!-- 统计信息 -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,16">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,16">
             <TextBlock x:Name="PluginCountText" Text="{Binding PluginCountText}" Foreground="#888" FontSize="12"/>
+            <TextBlock Text="{Binding RepositoryStatusText}" Foreground="#60A5FA"
+                       FontSize="12" Margin="16,0,0,0"/>
         </StackPanel>
 
         <!-- 插件列表 -->
-        <ScrollViewer Grid.Row="2" Style="{StaticResource DarkScrollViewer}"
+        <ScrollViewer Grid.Row="3" Style="{StaticResource DarkScrollViewer}"
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <!-- 无插件提示 -->


### PR DESCRIPTION
## Summary

- add a LibGit2Sharp-based `IPluginRepositoryService` with GitHub, CNB, and custom HTTPS channels
- support clone, fetch, reset recovery, serialized refreshes, startup background updates, and offline cache fallback
- switch the available-plugins catalog from built-in/`notice.json` discovery to the `catalog` branch `repo.json`
- add plugin-center controls for repository source, startup refresh, manual update, and reset

Part of Phase 2: 主程序仓库客户端

## Validation

- `dotnet build --no-restore` (0 errors; 4 pre-existing unused-event warnings)
- `dotnet test --no-restore` (1260 passed, 32 skipped, 0 failed)
- local LibGit2Sharp integration coverage for clone, no-op fetch, update fetch, and corrupted-cache reset
- GitHub and CNB `catalog` refs verified at `e0456b9a3b9095efbf5c8eb59d620c8ec9f8b0c1`