### PR TITLE
feat(plugins): add repository subscriptions and atomic installer

### DIFF
--- a/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
+++ b/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
@@ -111,6 +111,29 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public void ConfigureAppServices_RegistersRepositoryPluginServicesAsSingletons()
+    {
+        var services = new ServiceCollection();
+        services.ConfigureAppServices();
+
+        var subscriptions = services.Single(
+            service =>
+                service.ServiceType == typeof(IPluginSubscriptionService));
+        var installer = services.Single(
+            service => service.ServiceType == typeof(IPluginInstaller));
+        var writeCoordinator = services.Single(
+            service => service.ServiceType == typeof(PluginWriteCoordinator));
+
+        Assert.Equal(ServiceLifetime.Singleton, subscriptions.Lifetime);
+        Assert.Equal(
+            typeof(PluginSubscriptionService),
+            subscriptions.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, installer.Lifetime);
+        Assert.Equal(typeof(PluginInstaller), installer.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, writeCoordinator.Lifetime);
+    }
+
+    [Fact]
     public void ConfigureAppServices_RegistersRemotePluginServicesAsSingletons()
     {
         var services = new ServiceCollection();

--- a/AkashaNavigator.Tests/Services/PluginInstallationTransactionTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallationTransactionTests.cs
@@ -1,0 +1,159 @@
+using System.IO;
+using System.Text.Json;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginInstallationTransactionTests : IDisposable
+{
+    private const string PluginId = "transaction-test";
+
+    private readonly string _root =
+        Path.Combine(
+            Path.GetTempPath(),
+            $"AkashaNavigator.PluginTransactionTests.{Guid.NewGuid():N}");
+    private readonly string _libraryDirectory;
+    private readonly string _indexPath;
+    private readonly PluginLibrary _library;
+
+    public PluginInstallationTransactionTests()
+    {
+        _libraryDirectory = Path.Combine(_root, "installed");
+        _indexPath = Path.Combine(_root, "library.json");
+        Directory.CreateDirectory(_libraryDirectory);
+        _library = new PluginLibrary(
+            _libraryDirectory,
+            _indexPath,
+            Path.Combine(_root, "builtin"),
+            Mock.Of<ICompanionProcessManager>(),
+            CreateConsentService());
+    }
+
+    [Fact]
+    public void InstallOrUpdateFromDirectory_PreservesDeclaredSavedFiles()
+    {
+        var versionOne = CreateSource("1.0.0", "old code");
+        var installResult = _library.InstallOrUpdateFromDirectory(
+            versionOne,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository);
+        Assert.True(installResult.IsSuccess, installResult.Error?.Message);
+        var installedDirectory = Path.Combine(_libraryDirectory, PluginId);
+        File.WriteAllText(Path.Combine(installedDirectory, "config.json"), "user config");
+
+        var versionTwo = CreateSource("2.0.0", "new code");
+        File.WriteAllText(Path.Combine(versionTwo, "config.json"), "new default");
+        var updateResult = _library.InstallOrUpdateFromDirectory(
+            versionTwo,
+            new[] { "config.json" },
+            AppConstants.PluginInstallSourceRepository);
+
+        Assert.True(updateResult.IsSuccess, updateResult.Error?.Message);
+        Assert.Equal(
+            "user config",
+            File.ReadAllText(Path.Combine(installedDirectory, "config.json")));
+        Assert.Equal(
+            "new code",
+            File.ReadAllText(Path.Combine(installedDirectory, "main.js")));
+        Assert.Equal("2.0.0", _library.GetInstalledPluginInfo(PluginId)?.Version);
+    }
+
+    [Fact]
+    public void InstallOrUpdateFromDirectory_WhenIndexCommitFails_RestoresOldVersion()
+    {
+        var versionOne = CreateSource("1.0.0", "old code");
+        Assert.True(_library.InstallOrUpdateFromDirectory(
+            versionOne,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository).IsSuccess);
+        File.Delete(_indexPath);
+        Directory.CreateDirectory(_indexPath);
+
+        var versionTwo = CreateSource("2.0.0", "new code");
+        var result = _library.InstallOrUpdateFromDirectory(
+            versionTwo,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(PluginErrorCodes.InstallTransactionFailed, result.Error!.Code);
+        Assert.Equal(
+            "old code",
+            File.ReadAllText(
+                Path.Combine(_libraryDirectory, PluginId, "main.js")));
+        Assert.Equal("1.0.0", _library.GetInstalledPluginInfo(PluginId)?.Version);
+    }
+
+    [Fact]
+    public void InstallOrUpdateFromDirectory_RejectsEscapingSavedFileWithoutMutation()
+    {
+        var versionOne = CreateSource("1.0.0", "old code");
+        Assert.True(_library.InstallOrUpdateFromDirectory(
+            versionOne,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository).IsSuccess);
+        var versionTwo = CreateSource("2.0.0", "new code");
+
+        var result = _library.InstallOrUpdateFromDirectory(
+            versionTwo,
+            new[] { "../outside.txt" },
+            AppConstants.PluginInstallSourceRepository);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(
+            "old code",
+            File.ReadAllText(
+                Path.Combine(_libraryDirectory, PluginId, "main.js")));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_indexPath))
+            {
+                Directory.Delete(_indexPath);
+            }
+
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private string CreateSource(string version, string mainContent)
+    {
+        var source = Path.Combine(_root, $"source-{version}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(source);
+        File.WriteAllText(Path.Combine(source, "main.js"), mainContent);
+        File.WriteAllText(
+            Path.Combine(source, AppConstants.PluginManifestFileName),
+            JsonSerializer.Serialize(
+                new
+                {
+                    id = PluginId,
+                    name = "Transaction Test",
+                    version,
+                    main = "main.js",
+                    permissions = Array.Empty<string>()
+                }));
+        return source;
+    }
+
+    private static IPluginPermissionConsentService CreateConsentService()
+    {
+        var consent = new Mock<IPluginPermissionConsentService>();
+        consent
+            .Setup(service => service.EnsureHighRiskPermissionsApproved(
+                It.IsAny<PluginManifest>(),
+                It.IsAny<PluginPermissionConsentOperation>()))
+            .Returns(true);
+        return consent.Object;
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
@@ -1,0 +1,316 @@
+using System.IO;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginInstallerTests : IDisposable
+{
+    private const string PluginId = "sample-plugin";
+
+    private readonly string _repositoryDirectory =
+        Path.Combine(
+            Path.GetTempPath(),
+            $"AkashaNavigator.PluginInstallerTests.{Guid.NewGuid():N}");
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_AdaptsManifestAndSubscribes()
+    {
+        var entry = CreateEntry();
+        WriteCatalogPlugin(CreateManifest());
+        var repository = CreateRepositoryService(entry);
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord { PluginId = PluginId }));
+        subscriptions
+            .Setup(service => service.MarkInstalled(
+                PluginId,
+                "1.0.0",
+                new string('b', 40)))
+            .Returns(Result.Success());
+        PluginManifest? capturedManifest = null;
+        IReadOnlyList<string>? capturedSavedFiles = null;
+        string? capturedSource = null;
+        var library = new Mock<IPluginLibrary>();
+        library
+            .Setup(service => service.InstallOrUpdateFromDirectory(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>()))
+            .Callback<string, IReadOnlyList<string>, string>(
+                (directory, savedFiles, source) =>
+                {
+                    capturedManifest = PluginManifest
+                        .LoadFromFile(
+                            Path.Combine(
+                                directory,
+                                AppConstants.PluginManifestFileName))
+                        .Manifest;
+                    capturedSavedFiles = savedFiles.ToArray();
+                    capturedSource = source;
+                })
+            .Returns(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = PluginId,
+                        Name = "Sample",
+                        Version = "1.0.0"
+                    }));
+        var installer = new PluginInstaller(
+            repository.Object,
+            subscriptions.Object,
+            library.Object,
+            () => "1.4.0");
+
+        var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        Assert.Equal(PluginId, capturedManifest!.Id);
+        Assert.Equal("Colin", capturedManifest.Author);
+        Assert.Equal("1.4.0", capturedManifest.MinAppVersion);
+        Assert.Equal(new[] { "config.json" }, capturedSavedFiles);
+        Assert.Equal(AppConstants.PluginInstallSourceRepository, capturedSource);
+        subscriptions.Verify(
+            service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry),
+            Times.Once);
+        subscriptions.Verify(
+            service => service.MarkInstalled(
+                PluginId,
+                "1.0.0",
+                new string('b', 40)),
+            Times.Once);
+    }
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_RejectsSavedEntryScript()
+    {
+        var entry = CreateEntry();
+        var manifest = CreateManifest();
+        manifest.SavedFiles = new List<string> { "main.js" };
+        WriteCatalogPlugin(manifest);
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        var library = new Mock<IPluginLibrary>();
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions.Object,
+            library.Object,
+            () => "1.4.0");
+
+        var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(
+            PluginErrorCodes.RepositoryManifestInvalid,
+            result.Error!.Code);
+        subscriptions.Verify(
+            service => service.Subscribe(
+                It.IsAny<string>(),
+                It.IsAny<PluginRepositoryEntry>()),
+            Times.Never);
+        library.Verify(
+            service => service.InstallOrUpdateFromDirectory(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_RejectsUnsupportedDistribution()
+    {
+        var entry = CreateEntry();
+        entry.DistributionType = AppConstants.PluginDistributionRelease;
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            Mock.Of<IPluginSubscriptionService>(),
+            Mock.Of<IPluginLibrary>(),
+            () => "1.4.0");
+
+        var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(PluginErrorCodes.DistributionUnsupported, result.Error!.Code);
+    }
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_RejectsIncompatibleHost()
+    {
+        var entry = CreateEntry();
+        WriteCatalogPlugin(CreateManifest());
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            Mock.Of<IPluginSubscriptionService>(),
+            Mock.Of<IPluginLibrary>(),
+            () => "1.3.9");
+
+        var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(PluginErrorCodes.HostVersionTooLow, result.Error!.Code);
+    }
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_EndToEndPreservesUserFile()
+    {
+        var entry = CreateEntry();
+        var manifest = CreateManifest();
+        WriteCatalogPlugin(manifest);
+        var installRoot = Path.Combine(_repositoryDirectory, "test-install");
+        var library = new PluginLibrary(
+            Path.Combine(installRoot, "installed"),
+            Path.Combine(installRoot, "library.json"),
+            Path.Combine(installRoot, "builtin"),
+            Mock.Of<ICompanionProcessManager>(),
+            CreateConsentService());
+        var subscriptions = new PluginSubscriptionService(
+            Mock.Of<ILogService>(),
+            Path.Combine(installRoot, "plugin-subscriptions.json"));
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions,
+            library,
+            () => "1.4.0");
+
+        var installResult =
+            installer.InstallOrUpdateRepositoryPlugin(PluginId);
+        Assert.True(installResult.IsSuccess, installResult.Error?.Message);
+        var installedDirectory = Path.Combine(
+            installRoot,
+            "installed",
+            PluginId);
+        File.WriteAllText(
+            Path.Combine(installedDirectory, "config.json"),
+            "user config");
+
+        entry.Version = "2.0.0";
+        manifest.Version = "2.0.0";
+        WriteCatalogPlugin(manifest);
+        var updateResult =
+            installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(updateResult.IsSuccess, updateResult.Error?.Message);
+        Assert.Equal(
+            "user config",
+            File.ReadAllText(
+                Path.Combine(installedDirectory, "config.json")));
+        Assert.Equal("2.0.0", library.GetInstalledPluginInfo(PluginId)?.Version);
+        var subscription = subscriptions.GetSubscription(PluginId);
+        Assert.Equal("2.0.0", subscription?.InstalledVersion);
+        Assert.Equal(new string('b', 40), subscription?.InstalledCommit);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_repositoryDirectory))
+            {
+                Directory.Delete(_repositoryDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private Mock<IPluginRepositoryService> CreateRepositoryService(
+        PluginRepositoryEntry entry)
+    {
+        var repository = new Mock<IPluginRepositoryService>();
+        repository
+            .SetupGet(service => service.RepositoryDirectory)
+            .Returns(_repositoryDirectory);
+        repository
+            .SetupGet(service => service.Settings)
+            .Returns(new PluginRepositorySettings());
+        repository
+            .SetupGet(service => service.Current)
+            .Returns(
+                new PluginRepositorySnapshot(
+                    new PluginRepositoryIndex {
+                        SchemaVersion = 1,
+                        Commit = new string('a', 40),
+                        Plugins = new List<PluginRepositoryEntry> { entry }
+                    },
+                    new string('b', 40),
+                    false));
+        return repository;
+    }
+
+    private void WriteCatalogPlugin(CatalogPluginManifest manifest)
+    {
+        var pluginDirectory = Path.Combine(
+            _repositoryDirectory,
+            "plugins",
+            PluginId);
+        Directory.CreateDirectory(pluginDirectory);
+        File.WriteAllText(Path.Combine(pluginDirectory, "main.js"), "main");
+        File.WriteAllText(Path.Combine(pluginDirectory, "config.json"), "default");
+        var result = JsonHelper.SaveToFile(
+            Path.Combine(
+                pluginDirectory,
+                AppConstants.PluginRepositoryManifestFileName),
+            manifest);
+        Assert.True(result.IsSuccess, result.Error?.Message);
+    }
+
+    private static PluginRepositoryEntry CreateEntry()
+    {
+        return new PluginRepositoryEntry {
+            Id = PluginId,
+            Path = $"plugins/{PluginId}",
+            Name = "Sample",
+            Version = "1.0.0",
+            Description = "Sample plugin",
+            DistributionType = AppConstants.PluginDistributionRepository,
+            MinHostVersion = "1.4.0"
+        };
+    }
+
+    private static CatalogPluginManifest CreateManifest()
+    {
+        return new CatalogPluginManifest {
+            ManifestVersion = 2,
+            Id = PluginId,
+            Name = "Sample",
+            Version = "1.0.0",
+            Description = "Sample plugin",
+            Authors = new List<CatalogPluginAuthor> {
+                new() { Name = "Colin" }
+            },
+            Host = new CatalogPluginHost { MinVersion = "1.4.0" },
+            Main = "main.js",
+            Permissions = new List<string>(),
+            SavedFiles = new List<string> { "config.json" },
+            Library = new List<string>(),
+            HttpAllowedUrls = new List<string>(),
+            Distribution = new CatalogPluginDistribution {
+                Type = AppConstants.PluginDistributionRepository
+            }
+        };
+    }
+
+    private static IPluginPermissionConsentService CreateConsentService()
+    {
+        var consent = new Mock<IPluginPermissionConsentService>();
+        consent
+            .Setup(service => service.EnsureHighRiskPermissionsApproved(
+                It.IsAny<PluginManifest>(),
+                It.IsAny<PluginPermissionConsentOperation>()))
+            .Returns(true);
+        return consent.Object;
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginSubscriptionServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginSubscriptionServiceTests.cs
@@ -1,0 +1,172 @@
+using System.IO;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Services;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginSubscriptionServiceTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(
+            Path.GetTempPath(),
+            $"AkashaNavigator.PluginSubscriptionTests.{Guid.NewGuid():N}");
+    private readonly Mock<ILogService> _logService = new();
+
+    [Fact]
+    public void Subscribe_PersistsRepositoryPathAndReloads()
+    {
+        var statePath = GetStatePath();
+        var service = new PluginSubscriptionService(_logService.Object, statePath);
+
+        var result = service.Subscribe("official", CreateEntry());
+        var reloaded = new PluginSubscriptionService(_logService.Object, statePath);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        var record = Assert.Single(reloaded.GetSubscriptions());
+        Assert.Equal("sample-plugin", record.PluginId);
+        Assert.Equal("official", record.RepositoryId);
+        Assert.Equal("plugins/sample-plugin", record.RepositoryPath);
+        Assert.True(record.AutoUpdate);
+        Assert.True(record.IsAvailable);
+    }
+
+    [Fact]
+    public void Subscribe_RejectsSameIdFromDifferentRepository()
+    {
+        var service = new PluginSubscriptionService(
+            _logService.Object,
+            GetStatePath());
+        Assert.True(service.Subscribe("official", CreateEntry()).IsSuccess);
+
+        var result = service.Subscribe("custom", CreateEntry());
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(
+            "PLUGIN_SUBSCRIPTION_SOURCE_CONFLICT",
+            result.Error!.Code);
+    }
+
+    [Fact]
+    public void Reconcile_MarksRemovedPluginButKeepsSubscription()
+    {
+        var service = new PluginSubscriptionService(
+            _logService.Object,
+            GetStatePath());
+        Assert.True(service.Subscribe("official", CreateEntry()).IsSuccess);
+        var snapshot = new PluginRepositorySnapshot(
+            new PluginRepositoryIndex {
+                SchemaVersion = 1,
+                Commit = new string('a', 40),
+                Plugins = new List<PluginRepositoryEntry>()
+            },
+            new string('b', 40),
+            false);
+
+        var result = service.Reconcile("official", snapshot);
+
+        Assert.True(result.IsSuccess);
+        var record = Assert.Single(service.GetSubscriptions());
+        Assert.False(record.IsAvailable);
+        Assert.Equal("1.0.0", record.LastKnownVersion);
+    }
+
+    [Fact]
+    public void Unsubscribe_RemovesOnlySubscriptionState()
+    {
+        var service = new PluginSubscriptionService(
+            _logService.Object,
+            GetStatePath());
+        Assert.True(service.Subscribe("official", CreateEntry()).IsSuccess);
+        var installedMarker = Path.Combine(_root, "installed", "user-data.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(installedMarker)!);
+        File.WriteAllText(installedMarker, "keep");
+
+        var result = service.Unsubscribe("sample-plugin");
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(service.GetSubscriptions());
+        Assert.True(File.Exists(installedMarker));
+    }
+
+    [Fact]
+    public void Reconcile_ReportsInstalledSubscriptionUpdate()
+    {
+        var service = new PluginSubscriptionService(
+            _logService.Object,
+            GetStatePath());
+        Assert.True(service.Subscribe("official", CreateEntry()).IsSuccess);
+        Assert.True(
+            service.MarkInstalled(
+                "sample-plugin",
+                "1.0.0",
+                new string('a', 40)).IsSuccess);
+        var entry = CreateEntry();
+        entry.Version = "2.0.0";
+        var snapshot = new PluginRepositorySnapshot(
+            new PluginRepositoryIndex {
+                SchemaVersion = 1,
+                Commit = new string('b', 40),
+                Plugins = new List<PluginRepositoryEntry> { entry }
+            },
+            new string('c', 40),
+            false);
+
+        Assert.True(service.Reconcile("official", snapshot).IsSuccess);
+        var update = Assert.Single(service.GetAvailableUpdates());
+
+        Assert.Equal("sample-plugin", update.PluginId);
+        Assert.Equal("1.0.0", update.InstalledVersion);
+        Assert.Equal("2.0.0", update.AvailableVersion);
+        Assert.True(update.AutoUpdate);
+    }
+
+    [Fact]
+    public void SetAutoUpdate_PersistsPerPluginPreference()
+    {
+        var statePath = GetStatePath();
+        var service = new PluginSubscriptionService(_logService.Object, statePath);
+        Assert.True(service.Subscribe("official", CreateEntry()).IsSuccess);
+
+        var result = service.SetAutoUpdate("sample-plugin", enabled: false);
+        var reloaded = new PluginSubscriptionService(_logService.Object, statePath);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(
+            Assert.Single(reloaded.GetSubscriptions()).AutoUpdate);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private string GetStatePath()
+    {
+        return Path.Combine(_root, "plugin-subscriptions.json");
+    }
+
+    private static PluginRepositoryEntry CreateEntry()
+    {
+        return new PluginRepositoryEntry {
+            Id = "sample-plugin",
+            Path = "plugins/sample-plugin",
+            Name = "Sample",
+            Version = "1.0.0",
+            Description = "Sample plugin",
+            DistributionType = AppConstants.PluginDistributionRepository,
+            MinHostVersion = "1.4.0"
+        };
+    }
+}

--- a/AkashaNavigator.Tests/Services/PluginWriteCoordinatorTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginWriteCoordinatorTests.cs
@@ -1,0 +1,21 @@
+using AkashaNavigator.Services;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginWriteCoordinatorTests
+{
+    [Fact]
+    public async Task AcquireAsync_WaitsUntilCurrentWriterReleases()
+    {
+        var coordinator = new PluginWriteCoordinator();
+        using var firstWriter = coordinator.Acquire();
+
+        var secondWriterTask = coordinator.AcquireAsync().AsTask();
+
+        Assert.False(secondWriterTask.IsCompleted);
+        firstWriter.Dispose();
+        using var secondWriter = await secondWriterTask;
+        Assert.True(secondWriterTask.IsCompletedSuccessfully);
+    }
+}

--- a/AkashaNavigator.Tests/TestDoubles/PluginRefactorTestDoubles.cs
+++ b/AkashaNavigator.Tests/TestDoubles/PluginRefactorTestDoubles.cs
@@ -424,6 +424,14 @@ public sealed class FakePluginLibrary : IPluginLibrary
         return InstallPlugin(Path.GetFileNameWithoutExtension(archivePath));
     }
 
+    public Result<InstalledPluginInfo> InstallOrUpdateFromDirectory(
+        string sourceDirectory,
+        IReadOnlyList<string> savedFiles,
+        string source)
+    {
+        return InstallPlugin(Path.GetFileName(sourceDirectory), sourceDirectory);
+    }
+
     public Result UninstallPlugin(string pluginId, bool force = false, Func<string, List<string>>? getReferencingProfiles = null)
     {
         InstalledPlugins.Remove(pluginId);

--- a/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Windows;
 using AkashaNavigator.Core.Events;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Models.Common;
@@ -47,6 +48,9 @@ public sealed class AvailablePluginsPageViewModelTests
         Assert.Equal("2.0.0", alpha.Version);
         Assert.True(alpha.IsInstalled);
         Assert.True(alpha.HasUpdate);
+        Assert.Equal(
+            AppConstants.PluginDistributionRepository,
+            alpha.DistributionType);
         Assert.Equal(
             Path.Combine("C:\\catalog-cache", "plugins/alpha-plugin"),
             alpha.SourceDirectory);
@@ -108,19 +112,174 @@ public sealed class AvailablePluginsPageViewModelTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task InstallCommand_UsesUnifiedInstallerForRepositoryPlugin()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        var repositoryService = CreateRepositoryService(snapshot);
+        var installer = new Mock<IPluginInstaller>();
+        installer
+            .Setup(service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"))
+            .Returns(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = "alpha-plugin",
+                        Name = "Alpha",
+                        Version = "2.0.0"
+                    }));
+        var viewModel = CreateViewModel(
+            repositoryService.Object,
+            installer: installer.Object);
+        viewModel.RefreshPluginList();
+        var plugin = Assert.Single(
+            viewModel.Plugins.Where(item => item.Id == "alpha-plugin"));
+
+        await viewModel.InstallCommand.ExecuteAsync(plugin);
+
+        Assert.True(plugin.IsInstalled);
+        Assert.True(plugin.IsSubscribed);
+        Assert.False(plugin.HasUpdate);
+        installer.Verify(
+            service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void SubscribeAndUnsubscribeCommands_OnlyChangeSubscriptionState()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        var repositoryService = CreateRepositoryService(snapshot);
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                It.Is<PluginRepositoryEntry>(
+                    entry => entry.Id == "alpha-plugin")))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord {
+                        PluginId = "alpha-plugin"
+                    }));
+        subscriptions
+            .Setup(service => service.Unsubscribe("alpha-plugin"))
+            .Returns(Result.Success());
+        subscriptions
+            .Setup(service => service.Reconcile(
+                It.IsAny<string>(),
+                It.IsAny<PluginRepositorySnapshot>()))
+            .Returns(Result.Success());
+        subscriptions
+            .Setup(service => service.GetSubscriptions())
+            .Returns(Array.Empty<PluginSubscriptionRecord>());
+        var library = CreatePluginLibrary();
+        var viewModel = CreateViewModel(
+            repositoryService.Object,
+            library.Object,
+            subscriptionService: subscriptions.Object);
+        viewModel.RefreshPluginList();
+        var plugin = Assert.Single(
+            viewModel.Plugins.Where(item => item.Id == "alpha-plugin"));
+
+        viewModel.SubscribeCommand.Execute(plugin);
+        Assert.True(plugin.IsSubscribed);
+        viewModel.UnsubscribeCommand.Execute(plugin);
+
+        Assert.False(plugin.IsSubscribed);
+        library.Verify(
+            service => service.UninstallPlugin(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<Func<string, List<string>>?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void UpdateAllSubscribedCommand_InstallsEveryAvailableUpdate()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        var subscriptions = CreateSubscriptionService();
+        subscriptions
+            .Setup(service => service.GetAvailableUpdates())
+            .Returns(
+                new List<PluginSubscriptionUpdate> {
+                    new() {
+                        PluginId = "alpha-plugin",
+                        InstalledVersion = "1.0.0",
+                        AvailableVersion = "2.0.0",
+                        AutoUpdate = true
+                    }
+                });
+        var installer = new Mock<IPluginInstaller>();
+        installer
+            .Setup(service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"))
+            .Returns(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = "alpha-plugin",
+                        Name = "Alpha",
+                        Version = "2.0.0"
+                    }));
+        var viewModel = CreateViewModel(
+            CreateRepositoryService(snapshot).Object,
+            subscriptionService: subscriptions.Object,
+            installer: installer.Object);
+
+        viewModel.UpdateAllSubscribedCommand.Execute(null);
+
+        installer.Verify(
+            service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void RefreshPluginList_ShowsRemovedSubscriptionWithoutInstallAction()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        var subscriptions = CreateSubscriptionService();
+        subscriptions
+            .Setup(service => service.GetSubscriptions())
+            .Returns(
+                new List<PluginSubscriptionRecord> {
+                    new() {
+                        PluginId = "removed-plugin",
+                        RepositoryId = AppConstants.OfficialPluginRepositoryId,
+                        RepositoryPath = "plugins/removed-plugin",
+                        LastKnownVersion = "1.0.0",
+                        IsAvailable = false
+                    }
+                });
+        var viewModel = CreateViewModel(
+            CreateRepositoryService(snapshot).Object,
+            subscriptionService: subscriptions.Object);
+
+        viewModel.RefreshPluginList();
+
+        var removed = Assert.Single(
+            viewModel.Plugins.Where(
+                plugin => plugin.Id == "removed-plugin"));
+        Assert.False(removed.IsRepositoryAvailable);
+        Assert.Equal(Visibility.Visible, removed.RemovedTagVisibility);
+        Assert.Equal(Visibility.Collapsed, removed.InstallButtonVisibility);
+    }
+
     private static AvailablePluginsPageViewModel CreateViewModel(
         IPluginRepositoryService repositoryService,
         IPluginLibrary? pluginLibrary = null,
-        IPluginPackageService? packageService = null)
+        IPluginPackageService? packageService = null,
+        IPluginSubscriptionService? subscriptionService = null,
+        IPluginInstaller? installer = null)
     {
         var library = pluginLibrary ?? CreatePluginLibrary().Object;
         var configService = new Mock<IConfigService>();
         configService.SetupGet(service => service.Config).Returns(new AppConfig());
+        var subscriptions = subscriptionService ?? CreateSubscriptionService().Object;
         return new AvailablePluginsPageViewModel(
             library,
             Mock.Of<INotificationService>(),
             Mock.Of<IEventBus>(),
             repositoryService,
+            subscriptions,
+            installer ?? Mock.Of<IPluginInstaller>(),
             packageService ?? Mock.Of<IPluginPackageService>(),
             configService.Object);
     }
@@ -132,6 +291,20 @@ public sealed class AvailablePluginsPageViewModelTests
             .Setup(library => library.GetInstalledPlugins())
             .Returns(new List<InstalledPluginInfo>());
         return pluginLibrary;
+    }
+
+    private static Mock<IPluginSubscriptionService> CreateSubscriptionService()
+    {
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Reconcile(
+                It.IsAny<string>(),
+                It.IsAny<PluginRepositorySnapshot>()))
+            .Returns(Result.Success());
+        subscriptions
+            .Setup(service => service.GetSubscriptions())
+            .Returns(Array.Empty<PluginSubscriptionRecord>());
+        return subscriptions;
     }
 
     private static Mock<IPluginRepositoryService> CreateRepositoryService(

--- a/AkashaNavigator/App.xaml.cs
+++ b/AkashaNavigator/App.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -191,6 +192,10 @@ public partial class App : System.Windows.Application
             serviceProvider.GetRequiredService<IPluginResourceUpdateService>();
         var pluginRepositoryService =
             serviceProvider.GetRequiredService<IPluginRepositoryService>();
+        var pluginSubscriptionService =
+            serviceProvider.GetRequiredService<IPluginSubscriptionService>();
+        var pluginInstaller =
+            serviceProvider.GetRequiredService<IPluginInstaller>();
         var notificationService = serviceProvider.GetRequiredService<INotificationService>();
         _ = RefreshUpdateManifestInBackgroundAsync(
             updateManifestService,
@@ -199,19 +204,27 @@ public partial class App : System.Windows.Application
             logService);
         _ = RefreshPluginRepositoryInBackgroundAsync(
             pluginRepositoryService,
+            pluginSubscriptionService,
+            pluginInstaller,
             logService);
     }
 
     private static async Task RefreshPluginRepositoryInBackgroundAsync(
         IPluginRepositoryService pluginRepositoryService,
+        IPluginSubscriptionService pluginSubscriptionService,
+        IPluginInstaller pluginInstaller,
         ILogService logService)
     {
-        if (!pluginRepositoryService.Settings.AutoUpdateRepository)
+        var settings = pluginRepositoryService.Settings;
+        if (!settings.AutoUpdateRepository &&
+            !settings.AutoUpdateSubscribedPlugins)
         {
             return;
         }
 
-        var result = await pluginRepositoryService.RefreshAsync();
+        var result = settings.AutoUpdateRepository
+            ? await pluginRepositoryService.RefreshAsync()
+            : await pluginRepositoryService.InitializeAsync();
         if (result.IsFailure)
         {
             logService.Warn(
@@ -225,6 +238,45 @@ public partial class App : System.Windows.Application
                 nameof(App),
                 "后台更新插件仓库失败，继续使用本地缓存");
         }
+
+        if (result.IsFailure)
+        {
+            return;
+        }
+
+        var reconcileResult = pluginSubscriptionService.Reconcile(
+            AppConstants.OfficialPluginRepositoryId,
+            result.Value!);
+        if (reconcileResult.IsFailure)
+        {
+            logService.Warn(
+                nameof(App),
+                "同步插件订阅状态失败: {ErrorMessage}",
+                reconcileResult.Error?.Message ?? "未知错误");
+            return;
+        }
+
+        if (!settings.AutoUpdateSubscribedPlugins)
+        {
+            return;
+        }
+
+        foreach (var update in pluginSubscriptionService
+                     .GetAvailableUpdates()
+                     .Where(item => item.AutoUpdate))
+        {
+            var updateResult =
+                pluginInstaller.InstallOrUpdateRepositoryPlugin(update.PluginId);
+            if (updateResult.IsFailure)
+            {
+                logService.Warn(
+                    nameof(App),
+                    "自动更新插件 {PluginId} 失败: {ErrorMessage}",
+                    update.PluginId,
+                    updateResult.Error?.Message ?? "未知错误");
+            }
+        }
+
     }
 
     private static async Task RefreshUpdateManifestInBackgroundAsync(

--- a/AkashaNavigator/AppConstants.cs
+++ b/AkashaNavigator/AppConstants.cs
@@ -250,6 +250,11 @@ public static class AppConstants
     /// </summary>
     public const string PluginRepositoriesConfigFileName = "plugin-repositories.json";
 
+    public const string PluginRepositorySubscriptionsFileName =
+        "plugin-repository-subscriptions.json";
+
+    public const string PluginRepositoryManifestFileName = "manifest.json";
+
     /// <summary>
     /// 插件配置文件名
     /// </summary>
@@ -294,6 +299,8 @@ public static class AppConstants
     public const string PluginDistributionRepository = "repository";
 
     public const string PluginDistributionRelease = "release";
+
+    public const string PluginInstallSourceRepository = "repository";
 
     /// <summary>
     /// Notice 中拾取黑名单资源的键。

--- a/AkashaNavigator/Core/Interfaces/IPluginInstaller.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginInstaller.cs
@@ -1,0 +1,15 @@
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+/// <summary>
+/// 统一处理聚合仓库和本地 ZIP 插件安装。
+/// </summary>
+public interface IPluginInstaller
+{
+    Result<InstalledPluginInfo> InstallOrUpdateRepositoryPlugin(
+        string pluginId);
+
+    Result<InstalledPluginInfo> InstallPackage(string archivePath);
+}

--- a/AkashaNavigator/Core/Interfaces/IPluginLibrary.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginLibrary.cs
@@ -72,6 +72,14 @@ public interface IPluginLibrary
     Result<InstalledPluginInfo> InstallPluginPackage(string archivePath);
 
     /// <summary>
+    /// 从已验证的目录执行统一安装或更新事务。
+    /// </summary>
+    Result<InstalledPluginInfo> InstallOrUpdateFromDirectory(
+        string sourceDirectory,
+        IReadOnlyList<string> savedFiles,
+        string source);
+
+    /// <summary>
     /// 卸载插件
     /// </summary>
     /// <param name="pluginId">插件 ID</param>

--- a/AkashaNavigator/Core/Interfaces/IPluginSubscriptionService.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginSubscriptionService.cs
@@ -1,0 +1,35 @@
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+/// <summary>
+/// 管理聚合仓库插件订阅，不负责 Profile 关联或删除插件数据。
+/// </summary>
+public interface IPluginSubscriptionService
+{
+    IReadOnlyList<PluginSubscriptionRecord> GetSubscriptions();
+
+    PluginSubscriptionRecord? GetSubscription(string pluginId);
+
+    bool IsSubscribed(string pluginId);
+
+    IReadOnlyList<PluginSubscriptionUpdate> GetAvailableUpdates();
+
+    Result<PluginSubscriptionRecord> Subscribe(
+        string repositoryId,
+        PluginRepositoryEntry entry);
+
+    Result Unsubscribe(string pluginId);
+
+    Result SetAutoUpdate(string pluginId, bool enabled);
+
+    Result MarkInstalled(
+        string pluginId,
+        string installedVersion,
+        string installedCommit);
+
+    Result Reconcile(
+        string repositoryId,
+        PluginRepositorySnapshot snapshot);
+}

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -81,8 +81,17 @@ public static class ServiceCollectionExtensions
         // ConfigService（依赖LogService）
         services.AddSingleton<IConfigService, ConfigService>();
 
+        // 仓库同步、插件安装和卸载共享写入互斥。
+        services.AddSingleton<PluginWriteCoordinator>();
+
         // PluginRepositoryService（官方 catalog 缓存与索引）
         services.AddSingleton<IPluginRepositoryService, PluginRepositoryService>();
+
+        // PluginSubscriptionService（聚合仓库插件订阅）
+        services.AddSingleton<IPluginSubscriptionService, PluginSubscriptionService>();
+
+        // PluginInstaller（Manifest v2 适配与原子安装事务）
+        services.AddSingleton<IPluginInstaller, PluginInstaller>();
 
         // ShutdownCoordinator（依赖 LogService，统一编排幂等关停阶段）
         services.AddSingleton<ShutdownCoordinator>();

--- a/AkashaNavigator/Helpers/AppPaths.cs
+++ b/AkashaNavigator/Helpers/AppPaths.cs
@@ -127,6 +127,11 @@ public static class AppPaths
     /// </summary>
     public static string PluginRepositoriesConfigFilePath { get; }
 
+    /// <summary>
+    /// 聚合仓库插件订阅记录。
+    /// </summary>
+    public static string PluginRepositorySubscriptionsFilePath { get; }
+
     static AppPaths()
     {
         // 获取应用程序目录
@@ -181,6 +186,8 @@ public static class AppPaths
             Path.Combine(PluginRepositoriesDirectory, AppConstants.OfficialPluginRepositoryId);
         PluginRepositoriesConfigFilePath =
             Path.Combine(DataDirectory, AppConstants.PluginRepositoriesConfigFileName);
+        PluginRepositorySubscriptionsFilePath =
+            Path.Combine(DataDirectory, AppConstants.PluginRepositorySubscriptionsFileName);
 
         // 确保目录存在
         EnsureDirectoriesExist();

--- a/AkashaNavigator/Models/Common/ErrorCodes.cs
+++ b/AkashaNavigator/Models/Common/ErrorCodes.cs
@@ -74,6 +74,14 @@ public static class PluginErrorCodes
     /// 用户取消远程插件下载。
     /// </summary>
     public const string RemoteDownloadCanceled = "PLUGIN_REMOTE_DOWNLOAD_CANCELED";
+
+    public const string RepositoryPluginNotFound = "PLUGIN_REPOSITORY_NOT_FOUND";
+
+    public const string RepositoryManifestInvalid = "PLUGIN_REPOSITORY_MANIFEST_INVALID";
+
+    public const string DistributionUnsupported = "PLUGIN_DISTRIBUTION_UNSUPPORTED";
+
+    public const string InstallTransactionFailed = "PLUGIN_INSTALL_TRANSACTION_FAILED";
 }
 
 /// <summary>

--- a/AkashaNavigator/Models/Plugin/AvailablePluginItemModel.cs
+++ b/AkashaNavigator/Models/Plugin/AvailablePluginItemModel.cs
@@ -44,6 +44,10 @@ namespace AkashaNavigator.Models.Plugin
         /// </summary>
         public bool IsRemote { get; set; }
 
+        public string DistributionType { get; set; } = string.Empty;
+
+        public bool IsRepositoryAvailable { get; set; } = true;
+
         /// <summary>
         /// 已安装版本；未安装时为空。
         /// </summary>
@@ -112,14 +116,37 @@ namespace AkashaNavigator.Models.Plugin
         [ObservableProperty]
         private string _selectedSourceText = string.Empty;
 
+        [ObservableProperty]
+        private bool _isSubscribed;
+
+        public bool IsRepositoryDistribution =>
+            string.Equals(
+                DistributionType,
+                AppConstants.PluginDistributionRepository,
+                StringComparison.Ordinal);
+
+        private bool CanUseCatalogEntry =>
+            !IsRepositoryDistribution || IsRepositoryAvailable;
+
         public Visibility AvailableTagVisibility =>
-            !IsInstalled && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+            CanUseCatalogEntry && !IsInstalled && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public Visibility InstalledTagVisibility =>
-            IsInstalled && !HasUpdate && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+            CanUseCatalogEntry && IsInstalled && !HasUpdate && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public Visibility UpdateTagVisibility =>
-            IsInstalled && HasUpdate && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+            CanUseCatalogEntry && IsInstalled && HasUpdate && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+        public Visibility RemovedTagVisibility =>
+            IsRepositoryDistribution && !IsRepositoryAvailable
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public Visibility RemoteInfoVisibility =>
             IsRemote ? Visibility.Visible : Visibility.Collapsed;
@@ -128,16 +155,38 @@ namespace AkashaNavigator.Models.Plugin
             IsDownloading ? Visibility.Visible : Visibility.Collapsed;
 
         public Visibility InstallButtonVisibility =>
-            !IsInstalled && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+            IsRepositoryAvailable && !IsInstalled && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public Visibility UpdateButtonVisibility =>
-            IsInstalled && HasUpdate && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+            IsRepositoryAvailable && IsInstalled && HasUpdate && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public Visibility UninstallButtonVisibility =>
             IsInstalled && !HasUpdate && !IsDownloading ? Visibility.Visible : Visibility.Collapsed;
 
         public Visibility CancelButtonVisibility =>
             IsDownloading ? Visibility.Visible : Visibility.Collapsed;
+
+        public Visibility SubscribeButtonVisibility =>
+            IsRepositoryDistribution &&
+            IsRepositoryAvailable &&
+            !IsSubscribed &&
+            !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+        public Visibility UnsubscribeButtonVisibility =>
+            IsRepositoryDistribution && IsSubscribed && !IsDownloading
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+        public Visibility SubscriptionStatusVisibility =>
+            IsRepositoryDistribution && IsSubscribed
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         partial void OnIsInstalledChanged(bool value)
         {
@@ -154,6 +203,11 @@ namespace AkashaNavigator.Models.Plugin
             NotifyStateVisibilities();
         }
 
+        partial void OnIsSubscribedChanged(bool value)
+        {
+            NotifyStateVisibilities();
+        }
+
         private void NotifyStateVisibilities()
         {
             OnPropertyChanged(nameof(AvailableTagVisibility));
@@ -164,6 +218,9 @@ namespace AkashaNavigator.Models.Plugin
             OnPropertyChanged(nameof(UpdateButtonVisibility));
             OnPropertyChanged(nameof(UninstallButtonVisibility));
             OnPropertyChanged(nameof(CancelButtonVisibility));
+            OnPropertyChanged(nameof(SubscribeButtonVisibility));
+            OnPropertyChanged(nameof(UnsubscribeButtonVisibility));
+            OnPropertyChanged(nameof(SubscriptionStatusVisibility));
         }
     }
 }

--- a/AkashaNavigator/Models/Plugin/PluginCatalogEntry.cs
+++ b/AkashaNavigator/Models/Plugin/PluginCatalogEntry.cs
@@ -24,6 +24,8 @@ public sealed class PluginCatalogEntry
 
     public bool IsRemote { get; init; }
 
+    public string DistributionType { get; init; } = string.Empty;
+
     public string? MinHostVersion { get; init; }
 
     public PluginPackageInfo? Package { get; init; }

--- a/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
+++ b/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using AkashaNavigator.Models.Plugin;
+
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// Akasha 插件仓库 Manifest v2。
+/// </summary>
+public sealed class CatalogPluginManifest
+{
+    public int ManifestVersion { get; set; }
+
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public List<CatalogPluginAuthor> Authors { get; set; } = new();
+
+    public string? Homepage { get; set; }
+
+    public CatalogPluginHost Host { get; set; } = new();
+
+    public string Main { get; set; } = string.Empty;
+
+    public string? Settings { get; set; }
+
+    public List<string> Permissions { get; set; } = new();
+
+    public List<string> Profiles { get; set; } = new();
+
+    public List<string> Tags { get; set; } = new();
+
+    public List<string> SavedFiles { get; set; } = new();
+
+    public List<string> Library { get; set; } = new();
+
+    public List<string> HttpAllowedUrls { get; set; } = new();
+
+    public Dictionary<string, JsonElement> DefaultConfig { get; set; } = new();
+
+    public CatalogPluginDistribution Distribution { get; set; } = new();
+
+    public CatalogPluginBackend? Backend { get; set; }
+
+    public PluginManifest ToRuntimeManifest()
+    {
+        return new PluginManifest {
+            Id = Id,
+            Name = Name,
+            Version = Version,
+            Main = Main,
+            Description = Description,
+            Author = Authors?.FirstOrDefault()?.Name,
+            MinAppVersion = Host?.MinVersion,
+            Permissions = Permissions?.ToList() ?? new List<string>(),
+            Companion = Backend == null
+                ? null
+                : new CompanionManifest {
+                    Executable = Backend.Entry,
+                    ProtocolVersion = Backend.ProtocolVersion,
+                    Lifetime = Backend.Lifetime,
+                    SingleInstance = true
+                },
+            DefaultConfig = DefaultConfig == null
+                ? new Dictionary<string, JsonElement>()
+                : new Dictionary<string, JsonElement>(DefaultConfig),
+            Library = Library?.ToList() ?? new List<string>(),
+            HttpAllowedUrls = HttpAllowedUrls?.ToList() ?? new List<string>()
+        };
+    }
+}
+
+public sealed class CatalogPluginAuthor
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string? Url { get; set; }
+}
+
+public sealed class CatalogPluginHost
+{
+    public string MinVersion { get; set; } = string.Empty;
+}
+
+public sealed class CatalogPluginDistribution
+{
+    public string Type { get; set; } = string.Empty;
+
+    public string? Tag { get; set; }
+
+    public string? Asset { get; set; }
+
+    public string? Sha256 { get; set; }
+
+    public long? Size { get; set; }
+}
+
+public sealed class CatalogPluginBackend
+{
+    public string Type { get; set; } = string.Empty;
+
+    public string Entry { get; set; } = string.Empty;
+
+    public int ProtocolVersion { get; set; }
+
+    public string Lifetime { get; set; } = string.Empty;
+
+    public string IntegrityLevel { get; set; } = string.Empty;
+
+    public int ShutdownTimeoutMs { get; set; }
+}

--- a/AkashaNavigator/Models/PluginRepository/PluginSubscriptionState.cs
+++ b/AkashaNavigator/Models/PluginRepository/PluginSubscriptionState.cs
@@ -1,0 +1,44 @@
+namespace AkashaNavigator.Models.PluginRepository;
+
+/// <summary>
+/// 聚合仓库插件订阅持久化状态。
+/// </summary>
+public sealed class PluginSubscriptionState
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public List<PluginSubscriptionRecord> Subscriptions { get; set; } = new();
+}
+
+/// <summary>
+/// 单个插件的仓库订阅记录。取消订阅不会删除安装目录。
+/// </summary>
+public sealed record PluginSubscriptionRecord
+{
+    public string PluginId { get; init; } = string.Empty;
+
+    public string RepositoryId { get; init; } = string.Empty;
+
+    public string RepositoryPath { get; init; } = string.Empty;
+
+    public string LastKnownVersion { get; init; } = string.Empty;
+
+    public string InstalledVersion { get; init; } = string.Empty;
+
+    public string InstalledCommit { get; init; } = string.Empty;
+
+    public bool AutoUpdate { get; init; } = true;
+
+    public bool IsAvailable { get; init; } = true;
+}
+
+public sealed record PluginSubscriptionUpdate
+{
+    public string PluginId { get; init; } = string.Empty;
+
+    public string InstalledVersion { get; init; } = string.Empty;
+
+    public string AvailableVersion { get; init; } = string.Empty;
+
+    public bool AutoUpdate { get; init; }
+}

--- a/AkashaNavigator/Services/PluginInstaller.cs
+++ b/AkashaNavigator/Services/PluginInstaller.cs
@@ -1,0 +1,473 @@
+using System.IO;
+using System.Reflection;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 将 catalog Manifest v2 转换为当前宿主格式并提交到插件库。
+/// </summary>
+public sealed class PluginInstaller : IPluginInstaller
+{
+    private readonly IPluginRepositoryService _repositoryService;
+    private readonly IPluginSubscriptionService _subscriptionService;
+    private readonly IPluginLibrary _pluginLibrary;
+    private readonly ILogService? _logService;
+    private readonly Func<string> _hostVersionProvider;
+    private readonly object _installLock = new();
+
+    public PluginInstaller(
+        IPluginRepositoryService repositoryService,
+        IPluginSubscriptionService subscriptionService,
+        IPluginLibrary pluginLibrary,
+        ILogService logService)
+        : this(
+            repositoryService,
+            subscriptionService,
+            pluginLibrary,
+            GetCurrentHostVersion,
+            logService)
+    {
+    }
+
+    internal PluginInstaller(
+        IPluginRepositoryService repositoryService,
+        IPluginSubscriptionService subscriptionService,
+        IPluginLibrary pluginLibrary,
+        Func<string> hostVersionProvider)
+        : this(
+            repositoryService,
+            subscriptionService,
+            pluginLibrary,
+            hostVersionProvider,
+            null)
+    {
+    }
+
+    private PluginInstaller(
+        IPluginRepositoryService repositoryService,
+        IPluginSubscriptionService subscriptionService,
+        IPluginLibrary pluginLibrary,
+        Func<string> hostVersionProvider,
+        ILogService? logService)
+    {
+        _repositoryService =
+            repositoryService ?? throw new ArgumentNullException(nameof(repositoryService));
+        _subscriptionService =
+            subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+        _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
+        _hostVersionProvider =
+            hostVersionProvider ?? throw new ArgumentNullException(nameof(hostVersionProvider));
+        _logService = logService;
+    }
+
+    public Result<InstalledPluginInfo> InstallOrUpdateRepositoryPlugin(
+        string pluginId)
+    {
+        if (!PluginIdValidator.IsValid(pluginId))
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Validation(
+                    "PLUGIN_INSTALL_ID_INVALID",
+                    "插件 ID 无效"));
+        }
+
+        lock (_installLock)
+        {
+            return InstallOrUpdateRepositoryPluginCore(pluginId);
+        }
+    }
+
+    public Result<InstalledPluginInfo> InstallPackage(string archivePath)
+    {
+        lock (_installLock)
+        {
+            return _pluginLibrary.InstallPluginPackage(archivePath);
+        }
+    }
+
+    private Result<InstalledPluginInfo> InstallOrUpdateRepositoryPluginCore(
+        string pluginId)
+    {
+        var snapshot = _repositoryService.Current;
+        var entry = snapshot?.Index.Plugins.FirstOrDefault(
+            item => string.Equals(
+                item.Id,
+                pluginId,
+                StringComparison.OrdinalIgnoreCase));
+        if (entry == null)
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Plugin(
+                    PluginErrorCodes.RepositoryPluginNotFound,
+                    $"插件仓库中不存在 {pluginId}",
+                    pluginId: pluginId));
+        }
+
+        if (!string.Equals(
+                entry.DistributionType,
+                AppConstants.PluginDistributionRepository,
+                StringComparison.Ordinal))
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Plugin(
+                    PluginErrorCodes.DistributionUnsupported,
+                    $"当前阶段尚不支持 {entry.DistributionType} 分发",
+                    pluginId: pluginId));
+        }
+
+        var sourceDirectory = GetContainedPluginDirectory(
+            _repositoryService.RepositoryDirectory,
+            entry);
+        var manifestResult = JsonHelper.LoadFromFile<CatalogPluginManifest>(
+            Path.Combine(
+                sourceDirectory,
+                AppConstants.PluginRepositoryManifestFileName));
+        if (manifestResult.IsFailure)
+        {
+            return Result<InstalledPluginInfo>.Failure(manifestResult.Error!);
+        }
+
+        var manifest = manifestResult.Value!;
+        var validation = ValidateManifest(entry, manifest, sourceDirectory);
+        if (validation != null)
+        {
+            return Result<InstalledPluginInfo>.Failure(validation);
+        }
+
+        var subscriptionResult = _subscriptionService.Subscribe(
+            AppConstants.OfficialPluginRepositoryId,
+            entry);
+        if (subscriptionResult.IsFailure)
+        {
+            return Result<InstalledPluginInfo>.Failure(subscriptionResult.Error!);
+        }
+
+        var preparationDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"AkashaNavigator.RepositoryPlugin.{pluginId}.{Guid.NewGuid():N}");
+        try
+        {
+            CopyDirectorySecure(sourceDirectory, preparationDirectory);
+            var runtimeManifest = manifest.ToRuntimeManifest();
+            var saveResult = JsonHelper.SaveToFile(
+                Path.Combine(
+                    preparationDirectory,
+                    AppConstants.PluginManifestFileName),
+                runtimeManifest);
+            if (saveResult.IsFailure)
+            {
+                return Result<InstalledPluginInfo>.Failure(saveResult.Error!);
+            }
+
+            var installResult = _pluginLibrary.InstallOrUpdateFromDirectory(
+                preparationDirectory,
+                manifest.SavedFiles,
+                AppConstants.PluginInstallSourceRepository);
+            if (installResult.IsFailure)
+            {
+                return installResult;
+            }
+
+            var markResult = _subscriptionService.MarkInstalled(
+                pluginId,
+                installResult.Value!.Version,
+                snapshot!.CatalogCommit);
+            if (markResult?.IsFailure == true)
+            {
+                _logService?.Warn(
+                    nameof(PluginInstaller),
+                    "插件已安装，但保存订阅安装状态失败: {ErrorMessage}",
+                    markResult.Error?.Message ?? "未知错误");
+            }
+
+            return installResult;
+        }
+        catch (Exception ex)
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.FileSystem(
+                    PluginErrorCodes.InstallTransactionFailed,
+                    $"准备仓库插件失败: {ex.Message}",
+                    ex,
+                    sourceDirectory));
+        }
+        finally
+        {
+            TryDeleteDirectory(preparationDirectory);
+        }
+    }
+
+    private Error? ValidateManifest(
+        PluginRepositoryEntry entry,
+        CatalogPluginManifest manifest,
+        string sourceDirectory)
+    {
+        if (manifest.ManifestVersion != 2 ||
+            !string.Equals(manifest.Id, entry.Id, StringComparison.Ordinal) ||
+            !string.Equals(manifest.Version, entry.Version, StringComparison.Ordinal) ||
+            !string.Equals(manifest.Name, entry.Name, StringComparison.Ordinal) ||
+            !string.Equals(
+                manifest.Description,
+                entry.Description,
+                StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(manifest.Name) ||
+            string.IsNullOrWhiteSpace(manifest.Description) ||
+            manifest.Authors == null ||
+            manifest.Authors.Count == 0 ||
+            manifest.Authors.Any(author => string.IsNullOrWhiteSpace(author?.Name)) ||
+            manifest.Host == null ||
+            string.IsNullOrWhiteSpace(manifest.Host.MinVersion) ||
+            !string.Equals(
+                manifest.Host.MinVersion,
+                entry.MinHostVersion,
+                StringComparison.Ordinal) ||
+            manifest.DefaultConfig == null ||
+            manifest.Profiles == null ||
+            manifest.Tags == null ||
+            manifest.Distribution == null ||
+            !string.Equals(
+                manifest.Distribution.Type,
+                AppConstants.PluginDistributionRepository,
+                StringComparison.Ordinal) ||
+            manifest.Backend != null)
+        {
+            return InvalidManifest(entry.Id, "Manifest v2 与 repo.json 不一致");
+        }
+
+        if (PluginLibrary.CompareVersions(
+                _hostVersionProvider(),
+                manifest.Host.MinVersion) < 0)
+        {
+            return Error.Plugin(
+                PluginErrorCodes.HostVersionTooLow,
+                $"插件需要 AkashaNavigator {manifest.Host.MinVersion} 或更高版本",
+                pluginId: entry.Id);
+        }
+
+        if (manifest.Permissions == null ||
+            manifest.Permissions.Distinct(StringComparer.Ordinal).Count() !=
+            manifest.Permissions.Count ||
+            manifest.Permissions.Any(
+                permission => !PluginPermissions.IsValidPermission(permission)))
+        {
+            return InvalidManifest(entry.Id, "插件权限声明无效");
+        }
+
+        if (!ValidateRequiredFile(sourceDirectory, manifest.Main) ||
+            (!string.IsNullOrWhiteSpace(manifest.Settings) &&
+             !ValidateRequiredFile(sourceDirectory, manifest.Settings)))
+        {
+            return InvalidManifest(entry.Id, "插件入口或设置文件不存在");
+        }
+
+        if (manifest.Library == null ||
+            manifest.Library.Distinct(StringComparer.Ordinal).Count() !=
+            manifest.Library.Count ||
+            manifest.Library.Any(
+                path => !ValidateRequiredDirectory(sourceDirectory, path)))
+        {
+            return InvalidManifest(entry.Id, "插件 library 目录无效");
+        }
+
+        if (manifest.HttpAllowedUrls == null ||
+            manifest.HttpAllowedUrls.Any(
+                value => value == null ||
+                         !value.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
+        {
+            return InvalidManifest(entry.Id, "插件网络白名单无效");
+        }
+
+        manifest.SavedFiles ??= new List<string>();
+        var protectedPaths = new List<string> {
+            AppConstants.PluginManifestFileName,
+            AppConstants.PluginRepositoryManifestFileName,
+            manifest.Main
+        };
+        if (!string.IsNullOrWhiteSpace(manifest.Settings))
+        {
+            protectedPaths.Add(manifest.Settings);
+        }
+
+        protectedPaths.AddRange(manifest.Library);
+        if (manifest.SavedFiles.Distinct(StringComparer.Ordinal).Count() !=
+            manifest.SavedFiles.Count ||
+            manifest.SavedFiles.Any(
+                savedPath =>
+                    !IsSafeRelativePath(savedPath) ||
+                    protectedPaths.Any(
+                        protectedPath => PathsOverlap(savedPath, protectedPath))))
+        {
+            return InvalidManifest(
+                entry.Id,
+                "savedFiles 包含无效路径或覆盖插件代码");
+        }
+
+        var runtimeValidation = manifest.ToRuntimeManifest().Validate();
+        return runtimeValidation.IsValid
+            ? null
+            : InvalidManifest(entry.Id, "转换后的运行时清单无效");
+    }
+
+    private static bool ValidateRequiredFile(
+        string rootDirectory,
+        string relativePath)
+    {
+        return IsSafeRelativePath(relativePath) &&
+               File.Exists(GetContainedPath(rootDirectory, relativePath));
+    }
+
+    private static bool ValidateRequiredDirectory(
+        string rootDirectory,
+        string relativePath)
+    {
+        return IsSafeRelativePath(relativePath) &&
+               Directory.Exists(GetContainedPath(rootDirectory, relativePath));
+    }
+
+    private static bool IsSafeRelativePath(string? relativePath)
+    {
+        var segments = relativePath?.Split('/');
+        return !string.IsNullOrWhiteSpace(relativePath) &&
+               !Path.IsPathRooted(relativePath) &&
+               !relativePath.Contains('\\') &&
+               !relativePath.Contains(':') &&
+               segments != null &&
+               segments.All(
+                   segment =>
+                       !string.IsNullOrWhiteSpace(segment) &&
+                       segment != "." &&
+                       segment != "..");
+    }
+
+    private static bool PathsOverlap(string first, string second)
+    {
+        var normalizedFirst = first.TrimEnd('/');
+        var normalizedSecond = second.TrimEnd('/');
+        return string.Equals(
+                   normalizedFirst,
+                   normalizedSecond,
+                   StringComparison.OrdinalIgnoreCase) ||
+               normalizedFirst.StartsWith(
+                   normalizedSecond + "/",
+                   StringComparison.OrdinalIgnoreCase) ||
+               normalizedSecond.StartsWith(
+                   normalizedFirst + "/",
+                   StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetContainedPluginDirectory(
+        string repositoryDirectory,
+        PluginRepositoryEntry entry)
+    {
+        return GetContainedPath(repositoryDirectory, entry.Path);
+    }
+
+    private static string GetContainedPath(
+        string rootDirectory,
+        string relativePath)
+    {
+        if (!IsSafeRelativePath(relativePath))
+        {
+            throw new InvalidDataException($"插件路径无效: {relativePath}");
+        }
+
+        var root = Path.GetFullPath(rootDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(
+            Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!candidate.StartsWith(
+                root + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException($"插件路径逃逸仓库目录: {relativePath}");
+        }
+
+        return candidate;
+    }
+
+    private static void CopyDirectorySecure(
+        string sourceDirectory,
+        string targetDirectory)
+    {
+        var source = new DirectoryInfo(sourceDirectory);
+        if (!source.Exists)
+        {
+            throw new DirectoryNotFoundException(sourceDirectory);
+        }
+
+        if ((source.Attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidDataException("插件目录不能是重解析点");
+        }
+
+        Directory.CreateDirectory(targetDirectory);
+        foreach (var file in source.EnumerateFiles())
+        {
+            if ((file.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException($"插件包含重解析文件: {file.Name}");
+            }
+
+            file.CopyTo(Path.Combine(targetDirectory, file.Name), overwrite: true);
+        }
+
+        foreach (var directory in source.EnumerateDirectories())
+        {
+            if ((directory.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException($"插件包含重解析目录: {directory.Name}");
+            }
+
+            CopyDirectorySecure(
+                directory.FullName,
+                Path.Combine(targetDirectory, directory.Name));
+        }
+    }
+
+    private static Error InvalidManifest(
+        string pluginId,
+        string message)
+    {
+        return Error.Plugin(
+            PluginErrorCodes.RepositoryManifestInvalid,
+            message,
+            pluginId: pluginId);
+    }
+
+    private static string GetCurrentHostVersion()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            var metadataIndex = informational.IndexOf('+');
+            return metadataIndex > 0
+                ? informational[..metadataIndex]
+                : informational;
+        }
+
+        return assembly.GetName().Version?.ToString(3) ?? AppConstants.Version;
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // 准备目录由系统后续清理。
+        }
+    }
+}

--- a/AkashaNavigator/Services/PluginLibrary.cs
+++ b/AkashaNavigator/Services/PluginLibrary.cs
@@ -70,6 +70,7 @@ public class PluginLibrary : IPluginLibrary
     private readonly object _indexLock = new();
     private readonly ICompanionProcessManager _companionProcessManager;
     private readonly IPluginPermissionConsentService _permissionConsentService;
+    private readonly PluginWriteCoordinator _writeCoordinator;
     private readonly string _libraryDirectory;
     private readonly string _libraryIndexPath;
     private readonly string _builtInPluginsDirectory;
@@ -85,12 +86,15 @@ public class PluginLibrary : IPluginLibrary
     /// </summary>
     public PluginLibrary(
         ICompanionProcessManager companionProcessManager,
-        IPluginPermissionConsentService permissionConsentService)
+        IPluginPermissionConsentService permissionConsentService,
+        PluginWriteCoordinator writeCoordinator)
     {
         _companionProcessManager = companionProcessManager ??
                                    throw new ArgumentNullException(nameof(companionProcessManager));
         _permissionConsentService = permissionConsentService ??
                                     throw new ArgumentNullException(nameof(permissionConsentService));
+        _writeCoordinator =
+            writeCoordinator ?? throw new ArgumentNullException(nameof(writeCoordinator));
         _libraryDirectory = AppPaths.InstalledPluginsDirectory;
         _libraryIndexPath = AppPaths.LibraryIndexPath;
         _builtInPluginsDirectory = AppPaths.BuiltInPluginsDirectory;
@@ -111,6 +115,7 @@ public class PluginLibrary : IPluginLibrary
                                    throw new ArgumentNullException(nameof(companionProcessManager));
         _permissionConsentService = permissionConsentService ??
                                     throw new ArgumentNullException(nameof(permissionConsentService));
+        _writeCoordinator = new PluginWriteCoordinator();
         _libraryDirectory = Path.GetFullPath(libraryDirectory);
         _libraryIndexPath = Path.GetFullPath(indexPath);
         _builtInPluginsDirectory = Path.GetFullPath(builtInPluginsDirectory);
@@ -291,76 +296,26 @@ public class PluginLibrary : IPluginLibrary
 
         // 确定源目录
         var sourcePath = sourceDirectory ?? GetContainedPluginDirectory(_builtInPluginsDirectory, pluginId);
-
-        // 检查源目录是否存在
-        if (!Directory.Exists(sourcePath))
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.FileSystem(PluginErrorCodes.SourceNotFound, $"源目录不存在: {sourcePath}", filePath: sourcePath));
-        }
-
-        // 检查清单文件
-        var manifestPath = Path.Combine(sourcePath, "plugin.json");
-        var manifestResult = PluginManifest.LoadFromFile(manifestPath);
-        if (!manifestResult.IsSuccess)
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.Plugin(PluginErrorCodes.InvalidManifest, $"清单无效: {manifestResult.ErrorMessage ?? "未知错误"}",
-                             pluginId: pluginId));
-        }
-
-        var manifest = manifestResult.Manifest!;
-
-        // 确保插件ID匹配
-        if (!string.Equals(manifest.Id, pluginId, StringComparison.OrdinalIgnoreCase))
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.Plugin(PluginErrorCodes.InvalidManifest,
-                             $"清单中的ID ({manifest.Id}) 与请求的ID ({pluginId}) 不匹配", pluginId: pluginId));
-        }
-
-        if (!_permissionConsentService.EnsureHighRiskPermissionsApproved(
-                manifest,
-                PluginPermissionConsentOperation.Install))
+        var manifestResult = PluginManifest.LoadFromFile(
+            Path.Combine(sourcePath, AppConstants.PluginManifestFileName));
+        if (!manifestResult.IsSuccess ||
+            manifestResult.Manifest == null ||
+            !string.Equals(
+                manifestResult.Manifest.Id,
+                pluginId,
+                StringComparison.OrdinalIgnoreCase))
         {
             return Result<InstalledPluginInfo>.Failure(
                 Error.Plugin(
-                    PluginErrorCodes.PermissionConsentDeclined,
-                    "未获得或无法保存插件请求的高风险权限授权",
+                    PluginErrorCodes.InvalidManifest,
+                    $"插件源清单与请求的 ID {pluginId} 不匹配",
                     pluginId: pluginId));
         }
 
-        // 复制插件文件到用户插件库（不要写入内置 Repos 目录）
-        var targetDir = GetContainedPluginDirectory(LibraryDirectory, pluginId);
-        try
-        {
-            CopyDirectory(sourcePath, targetDir);
-        }
-        catch (Exception ex)
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.FileSystem(PluginErrorCodes.CopyFailed, $"文件复制失败: {ex.Message}", ex, filePath: targetDir));
-        }
-
-        // 更新索引
-        var entry =
-            new InstalledPluginEntry { Id = pluginId, Version = manifest.Version ?? "1.0.0", InstalledAt = DateTime.Now,
-                                       Source = sourceDirectory == null ? "builtin" : "external" };
-
-        lock (_indexLock)
-        {
-            _index.Plugins.Add(entry);
-            SaveIndex();
-        }
-
-        // 创建插件信息
-        var pluginInfo = InstalledPluginInfo.FromManifest(manifest, entry.Source);
-        pluginInfo.InstalledAt = entry.InstalledAt;
-
-        // 触发事件
-        OnPluginChanged(new PluginLibraryChangedEventArgs(PluginLibraryChangeType.Installed, pluginId, pluginInfo));
-
-        return Result<InstalledPluginInfo>.Success(pluginInfo);
+        return InstallOrUpdateFromDirectory(
+            sourcePath,
+            Array.Empty<string>(),
+            sourceDirectory == null ? "builtin" : "external");
     }
 
     /// <summary>
@@ -403,9 +358,10 @@ public class PluginLibrary : IPluginLibrary
             var pluginId = manifest.Id!;
             ValidatePackageEntryFiles(pluginDirectory, manifest);
 
-            return IsInstalled(pluginId)
-                ? UpdatePluginFromDirectory(pluginDirectory, manifest)
-                : InstallPlugin(pluginId, pluginDirectory);
+            return InstallOrUpdateFromDirectory(
+                pluginDirectory,
+                Array.Empty<string>(),
+                "external");
         }
         catch (InvalidDataException ex)
         {
@@ -442,10 +398,49 @@ public class PluginLibrary : IPluginLibrary
         }
     }
 
-    private Result<InstalledPluginInfo> UpdatePluginFromDirectory(
+    public Result<InstalledPluginInfo> InstallOrUpdateFromDirectory(
         string sourceDirectory,
-        PluginManifest manifest)
+        IReadOnlyList<string> savedFiles,
+        string source)
     {
+        if (savedFiles == null)
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Validation(
+                    PluginErrorCodes.InvalidManifest,
+                    "savedFiles 不能为空"));
+        }
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Validation(
+                    PluginErrorCodes.InvalidManifest,
+                    "插件安装来源不能为空"));
+        }
+
+        if (string.IsNullOrWhiteSpace(sourceDirectory) ||
+            !Directory.Exists(sourceDirectory))
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.FileSystem(
+                    PluginErrorCodes.SourceNotFound,
+                    $"插件源目录不存在: {sourceDirectory}",
+                    filePath: sourceDirectory));
+        }
+
+        using var writeOperation = _writeCoordinator.Acquire();
+        var manifestResult = PluginManifest.LoadFromFile(
+            Path.Combine(sourceDirectory, AppConstants.PluginManifestFileName));
+        if (!manifestResult.IsSuccess || manifestResult.Manifest == null)
+        {
+            return Result<InstalledPluginInfo>.Failure(
+                Error.Plugin(
+                    PluginErrorCodes.InvalidManifest,
+                    $"清单无效: {manifestResult.ErrorMessage ?? "未知错误"}"));
+        }
+
+        var manifest = manifestResult.Manifest;
         var pluginId = manifest.Id!;
         InstalledPluginEntry? entry;
         lock (_indexLock)
@@ -454,34 +449,30 @@ public class PluginLibrary : IPluginLibrary
                 item => string.Equals(item.Id, pluginId, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (entry == null)
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.Plugin(PluginErrorCodes.NotInstalled, $"插件 {pluginId} 未安装", pluginId: pluginId));
-        }
-
         var incomingVersion = manifest.Version ?? "0.0.0";
-        if (CompareVersions(incomingVersion, entry.Version) <= 0)
+        var isUpdate = entry != null;
+        if (isUpdate && CompareVersions(incomingVersion, entry!.Version) <= 0)
         {
             return Result<InstalledPluginInfo>.Failure(
                 Error.Plugin(
                     PluginErrorCodes.VersionNotNewer,
-                    $"插件包版本 {incomingVersion} 不高于已安装版本 {entry.Version}",
+                    $"插件版本 {incomingVersion} 不高于已安装版本 {entry.Version}",
                     pluginId: pluginId));
         }
 
         if (!_permissionConsentService.EnsureHighRiskPermissionsApproved(
                 manifest,
-                PluginPermissionConsentOperation.Update))
+                isUpdate
+                    ? PluginPermissionConsentOperation.Update
+                    : PluginPermissionConsentOperation.Install))
         {
             return Result<InstalledPluginInfo>.Failure(
                 Error.Plugin(
                     PluginErrorCodes.PermissionConsentDeclined,
-                    "未获得或无法保存更新所需的高风险权限授权",
+                    "未获得或无法保存插件所需的高风险权限授权",
                     pluginId: pluginId));
         }
 
-        Directory.CreateDirectory(LibraryDirectory);
         var targetDirectory = GetContainedPluginDirectory(LibraryDirectory, pluginId);
         var stagingDirectory = Path.Combine(
             LibraryDirectory,
@@ -489,40 +480,87 @@ public class PluginLibrary : IPluginLibrary
         var backupDirectory = Path.Combine(
             LibraryDirectory,
             $".package-backup-{pluginId}-{Guid.NewGuid():N}");
-        InstalledPluginInfo pluginInfo;
+        var previousVersion = entry?.Version;
+        var previousSource = entry?.Source;
+        var addedEntry = false;
+        var targetMovedToBackup = false;
+        var stagingMovedToTarget = false;
 
         try
         {
+            Directory.CreateDirectory(LibraryDirectory);
             CopyDirectory(sourceDirectory, stagingDirectory);
+            if (isUpdate)
+            {
+                RestoreSavedFiles(
+                    targetDirectory,
+                    stagingDirectory,
+                    savedFiles);
+            }
+
             StopCompanionBeforeFileMutation(pluginId);
 
             if (Directory.Exists(targetDirectory))
             {
                 Directory.Move(targetDirectory, backupDirectory);
+                targetMovedToBackup = true;
             }
 
             Directory.Move(stagingDirectory, targetDirectory);
+            stagingMovedToTarget = true;
 
             lock (_indexLock)
             {
-                entry.Version = incomingVersion;
-                entry.Source = "external";
-                SaveIndex();
-            }
+                if (entry == null)
+                {
+                    entry = new InstalledPluginEntry {
+                        Id = pluginId,
+                        Version = incomingVersion,
+                        InstalledAt = DateTime.Now,
+                        Source = source
+                    };
+                    _index.Plugins.Add(entry);
+                    addedEntry = true;
+                }
+                else
+                {
+                    entry.Version = incomingVersion;
+                    entry.Source = source;
+                }
 
-            pluginInfo = InstalledPluginInfo.FromManifest(manifest, entry.Source);
-            pluginInfo.InstalledAt = entry.InstalledAt;
+                var saveResult = JsonHelper.SaveToFile(LibraryIndexPath, _index);
+                if (saveResult.IsFailure)
+                {
+                    throw new IOException(saveResult.Error?.Message);
+                }
+            }
         }
         catch (Exception ex)
         {
+            lock (_indexLock)
+            {
+                if (addedEntry && entry != null)
+                {
+                    _index.Plugins.Remove(entry);
+                }
+                else if (entry != null)
+                {
+                    entry.Version = previousVersion ?? entry.Version;
+                    entry.Source = previousSource ?? entry.Source;
+                }
+            }
+
             try
             {
-                if (Directory.Exists(targetDirectory) && Directory.Exists(backupDirectory))
+                if (stagingMovedToTarget &&
+                    Directory.Exists(targetDirectory))
                 {
                     Directory.Delete(targetDirectory, recursive: true);
                 }
 
-                if (!Directory.Exists(targetDirectory) && Directory.Exists(backupDirectory))
+                if (targetMovedToBackup &&
+                    !Directory.Exists(targetDirectory) &&
+                    Directory.Exists(backupDirectory))
                 {
                     Directory.Move(backupDirectory, targetDirectory);
                 }
@@ -539,11 +577,14 @@ public class PluginLibrary : IPluginLibrary
 
             return Result<InstalledPluginInfo>.Failure(
                 Error.FileSystem(
-                    PluginErrorCodes.CopyFailed,
-                    $"插件更新失败: {ex.Message}",
+                    PluginErrorCodes.InstallTransactionFailed,
+                    $"插件安装事务失败: {ex.Message}",
                     ex,
                     filePath: targetDirectory));
         }
+
+        var pluginInfo = InstalledPluginInfo.FromManifest(manifest, entry!.Source);
+        pluginInfo.InstalledAt = entry.InstalledAt;
 
         try
         {
@@ -557,11 +598,90 @@ public class PluginLibrary : IPluginLibrary
             // 新版本已经提交；旧版本备份可在后续维护时清理，不能因此回滚索引。
         }
 
+        writeOperation.Dispose();
         OnPluginChanged(new PluginLibraryChangedEventArgs(
-            PluginLibraryChangeType.Updated,
+            isUpdate
+                ? PluginLibraryChangeType.Updated
+                : PluginLibraryChangeType.Installed,
             pluginId,
             pluginInfo));
         return Result<InstalledPluginInfo>.Success(pluginInfo);
+    }
+
+    private static void RestoreSavedFiles(
+        string sourceRoot,
+        string stagingRoot,
+        IEnumerable<string> savedFiles)
+    {
+        if (!Directory.Exists(sourceRoot))
+        {
+            return;
+        }
+
+        foreach (var relativePath in savedFiles.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var sourcePath = GetContainedRelativePath(sourceRoot, relativePath);
+            var destinationPath = GetContainedRelativePath(stagingRoot, relativePath);
+            if (File.Exists(sourcePath))
+            {
+                DeletePathIfExists(destinationPath);
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                File.Copy(sourcePath, destinationPath, overwrite: true);
+            }
+            else if (Directory.Exists(sourcePath))
+            {
+                DeletePathIfExists(destinationPath);
+                CopyDirectory(sourcePath, destinationPath);
+            }
+        }
+    }
+
+    private static string GetContainedRelativePath(
+        string rootDirectory,
+        string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath) ||
+            Path.IsPathRooted(relativePath) ||
+            relativePath.Contains('\\') ||
+            relativePath.Contains(':') ||
+            relativePath.Split(
+                    '/',
+                    StringSplitOptions.None)
+                .Any(
+                    segment =>
+                        string.IsNullOrWhiteSpace(segment) ||
+                        segment == "." ||
+                        segment == ".."))
+        {
+            throw new InvalidDataException(
+                $"savedFiles 包含不安全路径: {relativePath}");
+        }
+
+        var root = Path.GetFullPath(rootDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(
+            Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!candidate.StartsWith(
+                root + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"savedFiles 路径逃逸插件目录: {relativePath}");
+        }
+
+        return candidate;
+    }
+
+    private static void DeletePathIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+        else if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
     }
 
     private static void ExtractPluginPackage(string archivePath, string extractionRoot)
@@ -809,6 +929,8 @@ public class PluginLibrary : IPluginLibrary
                 Error.Plugin(PluginErrorCodes.InvalidManifest, "插件 ID 格式无效", pluginId: pluginId));
         }
 
+        using var writeOperation = _writeCoordinator.Acquire();
+
         // 检查是否已安装
         if (!IsInstalled(pluginId))
         {
@@ -861,6 +983,7 @@ public class PluginLibrary : IPluginLibrary
             SaveIndex();
         }
 
+        writeOperation.Dispose();
         // 触发事件
         OnPluginChanged(new PluginLibraryChangedEventArgs(PluginLibraryChangeType.Uninstalled, pluginId));
 
@@ -974,6 +1097,8 @@ public class PluginLibrary : IPluginLibrary
     /// <returns>更新结果</returns>
     public UpdateResult UpdatePlugin(string pluginId)
     {
+        using var writeOperation = _writeCoordinator.Acquire();
+
         // 检查是否有可用更新
         var checkResult = CheckForUpdate(pluginId);
         if (!checkResult.HasUpdate)
@@ -1038,6 +1163,7 @@ public class PluginLibrary : IPluginLibrary
             // 获取更新后的插件信息
             var pluginInfo = GetInstalledPluginInfo(pluginId);
 
+            writeOperation.Dispose();
             // 触发 PluginChanged 事件 (Updated)
             OnPluginChanged(new PluginLibraryChangedEventArgs(PluginLibraryChangeType.Updated, pluginId, pluginInfo));
 

--- a/AkashaNavigator/Services/PluginRepositoryService.cs
+++ b/AkashaNavigator/Services/PluginRepositoryService.cs
@@ -17,18 +17,22 @@ public sealed class PluginRepositoryService : IPluginRepositoryService
     private readonly IPluginRepositoryGitClient _gitClient;
     private readonly string _repositoryDirectory;
     private readonly string _settingsFilePath;
+    private readonly PluginWriteCoordinator _writeCoordinator;
     private readonly object _settingsLock = new();
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
     private PluginRepositorySnapshot? _current;
     private PluginRepositorySettings _settings;
 
-    public PluginRepositoryService(ILogService logService)
+    public PluginRepositoryService(
+        ILogService logService,
+        PluginWriteCoordinator writeCoordinator)
         : this(
             logService,
             new PluginRepositoryGitClient(),
             AppPaths.OfficialPluginRepositoryDirectory,
-            AppPaths.PluginRepositoriesConfigFilePath)
+            AppPaths.PluginRepositoriesConfigFilePath,
+            writeCoordinator)
     {
     }
 
@@ -37,6 +41,21 @@ public sealed class PluginRepositoryService : IPluginRepositoryService
         IPluginRepositoryGitClient gitClient,
         string repositoryDirectory,
         string settingsFilePath)
+        : this(
+            logService,
+            gitClient,
+            repositoryDirectory,
+            settingsFilePath,
+            new PluginWriteCoordinator())
+    {
+    }
+
+    private PluginRepositoryService(
+        ILogService logService,
+        IPluginRepositoryGitClient gitClient,
+        string repositoryDirectory,
+        string settingsFilePath,
+        PluginWriteCoordinator writeCoordinator)
     {
         _logService = logService ?? throw new ArgumentNullException(nameof(logService));
         _gitClient = gitClient ?? throw new ArgumentNullException(nameof(gitClient));
@@ -44,6 +63,8 @@ public sealed class PluginRepositoryService : IPluginRepositoryService
             repositoryDirectory ?? throw new ArgumentNullException(nameof(repositoryDirectory));
         _settingsFilePath =
             settingsFilePath ?? throw new ArgumentNullException(nameof(settingsFilePath));
+        _writeCoordinator =
+            writeCoordinator ?? throw new ArgumentNullException(nameof(writeCoordinator));
         _settings = LoadSettings();
         _current = LoadSnapshot(usedCache: true).Value;
     }
@@ -121,6 +142,8 @@ public sealed class PluginRepositoryService : IPluginRepositoryService
         {
             await _writeLock.WaitAsync(cancellationToken);
             lockTaken = true;
+            using var sharedWrite =
+                await _writeCoordinator.AcquireAsync(cancellationToken);
 
             settings = Settings;
             var validation = ValidateSettings(settings);

--- a/AkashaNavigator/Services/PluginSubscriptionService.cs
+++ b/AkashaNavigator/Services/PluginSubscriptionService.cs
@@ -1,0 +1,478 @@
+using System.IO;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 以独立文件保存聚合仓库插件订阅。
+/// </summary>
+public sealed class PluginSubscriptionService : IPluginSubscriptionService
+{
+    private readonly ILogService _logService;
+    private readonly IPluginLibrary? _pluginLibrary;
+    private readonly string _stateFilePath;
+    private readonly object _stateLock = new();
+    private PluginSubscriptionState _state;
+
+    public PluginSubscriptionService(
+        ILogService logService,
+        IPluginLibrary pluginLibrary)
+        : this(
+            logService,
+            AppPaths.PluginRepositorySubscriptionsFilePath,
+            pluginLibrary)
+    {
+    }
+
+    internal PluginSubscriptionService(
+        ILogService logService,
+        string stateFilePath)
+        : this(logService, stateFilePath, null)
+    {
+    }
+
+    private PluginSubscriptionService(
+        ILogService logService,
+        string stateFilePath,
+        IPluginLibrary? pluginLibrary)
+    {
+        _logService = logService ?? throw new ArgumentNullException(nameof(logService));
+        _pluginLibrary = pluginLibrary;
+        _stateFilePath = stateFilePath ?? throw new ArgumentNullException(nameof(stateFilePath));
+        _state = LoadState();
+    }
+
+    public IReadOnlyList<PluginSubscriptionRecord> GetSubscriptions()
+    {
+        lock (_stateLock)
+        {
+            return _state.Subscriptions
+                .Select(Clone)
+                .OrderBy(record => record.PluginId, StringComparer.Ordinal)
+                .ToArray();
+        }
+    }
+
+    public PluginSubscriptionRecord? GetSubscription(string pluginId)
+    {
+        if (!PluginIdValidator.IsValid(pluginId))
+        {
+            return null;
+        }
+
+        lock (_stateLock)
+        {
+            var record = Find(pluginId);
+            return record == null ? null : Clone(record);
+        }
+    }
+
+    public bool IsSubscribed(string pluginId)
+    {
+        return GetSubscription(pluginId) != null;
+    }
+
+    public IReadOnlyList<PluginSubscriptionUpdate> GetAvailableUpdates()
+    {
+        lock (_stateLock)
+        {
+            var installed = _pluginLibrary?
+                .GetInstalledPlugins()
+                .ToDictionary(
+                    plugin => plugin.Id,
+                    StringComparer.OrdinalIgnoreCase);
+            return _state.Subscriptions
+                .Select(
+                    record => new {
+                        Record = record,
+                        InstalledVersion =
+                            installed?.GetValueOrDefault(record.PluginId)?.Version ??
+                            record.InstalledVersion
+                    })
+                .Where(
+                    item =>
+                        item.Record.IsAvailable &&
+                        !string.IsNullOrWhiteSpace(item.InstalledVersion) &&
+                        PluginLibrary.CompareVersions(
+                            item.Record.LastKnownVersion,
+                            item.InstalledVersion) > 0)
+                .Select(
+                    item => new PluginSubscriptionUpdate {
+                        PluginId = item.Record.PluginId,
+                        InstalledVersion = item.InstalledVersion,
+                        AvailableVersion = item.Record.LastKnownVersion,
+                        AutoUpdate = item.Record.AutoUpdate
+                    })
+                .OrderBy(update => update.PluginId, StringComparer.Ordinal)
+                .ToArray();
+        }
+    }
+
+    public Result<PluginSubscriptionRecord> Subscribe(
+        string repositoryId,
+        PluginRepositoryEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        var validation = ValidateSubscription(repositoryId, entry);
+        if (validation != null)
+        {
+            return Result<PluginSubscriptionRecord>.Failure(validation);
+        }
+
+        lock (_stateLock)
+        {
+            var existing = Find(entry.Id);
+            if (existing != null &&
+                (!string.Equals(
+                     existing.RepositoryId,
+                     repositoryId,
+                     StringComparison.Ordinal) ||
+                 !string.Equals(
+                     existing.RepositoryPath,
+                     entry.Path,
+                     StringComparison.Ordinal)))
+            {
+                return Result<PluginSubscriptionRecord>.Failure(
+                    Error.BusinessLogic(
+                        "PLUGIN_SUBSCRIPTION_SOURCE_CONFLICT",
+                        $"插件 {entry.Id} 已订阅到其他仓库来源"));
+            }
+
+            var updated = new PluginSubscriptionRecord {
+                PluginId = entry.Id,
+                RepositoryId = repositoryId,
+                RepositoryPath = entry.Path,
+                LastKnownVersion = entry.Version,
+                InstalledVersion = existing?.InstalledVersion ?? string.Empty,
+                InstalledCommit = existing?.InstalledCommit ?? string.Empty,
+                AutoUpdate = existing?.AutoUpdate ?? true,
+                IsAvailable = true
+            };
+            var previousState = CloneState(_state);
+            if (existing == null)
+            {
+                _state.Subscriptions.Add(updated);
+            }
+            else
+            {
+                _state.Subscriptions[_state.Subscriptions.IndexOf(existing)] = updated;
+            }
+
+            var saveResult = SaveState();
+            if (saveResult.IsFailure)
+            {
+                _state = previousState;
+                return Result<PluginSubscriptionRecord>.Failure(saveResult.Error!);
+            }
+
+            return Result<PluginSubscriptionRecord>.Success(Clone(updated));
+        }
+    }
+
+    public Result Unsubscribe(string pluginId)
+    {
+        if (!PluginIdValidator.IsValid(pluginId))
+        {
+            return Result.Failure(
+                Error.Validation(
+                    "PLUGIN_SUBSCRIPTION_ID_INVALID",
+                    "插件订阅 ID 无效"));
+        }
+
+        lock (_stateLock)
+        {
+            var existing = Find(pluginId);
+            if (existing == null)
+            {
+                return Result.Success();
+            }
+
+            var previousState = CloneState(_state);
+            _state.Subscriptions.Remove(existing);
+            var saveResult = SaveState();
+            if (saveResult.IsFailure)
+            {
+                _state = previousState;
+                return saveResult;
+            }
+
+            return Result.Success();
+        }
+    }
+
+    public Result SetAutoUpdate(string pluginId, bool enabled)
+    {
+        return UpdateSubscription(
+            pluginId,
+            record => record with { AutoUpdate = enabled });
+    }
+
+    public Result MarkInstalled(
+        string pluginId,
+        string installedVersion,
+        string installedCommit)
+    {
+        if (string.IsNullOrWhiteSpace(installedVersion) ||
+            string.IsNullOrWhiteSpace(installedCommit))
+        {
+            return Result.Failure(
+                Error.Validation(
+                    "PLUGIN_SUBSCRIPTION_INSTALL_STATE_INVALID",
+                    "插件安装版本和 catalog commit 不能为空"));
+        }
+
+        return UpdateSubscription(
+            pluginId,
+            record => record with {
+                InstalledVersion = installedVersion,
+                InstalledCommit = installedCommit
+            });
+    }
+
+    public Result Reconcile(
+        string repositoryId,
+        PluginRepositorySnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (string.IsNullOrWhiteSpace(repositoryId))
+        {
+            return Result.Failure(
+                Error.Validation(
+                    "PLUGIN_SUBSCRIPTION_REPOSITORY_INVALID",
+                    "插件仓库 ID 不能为空"));
+        }
+
+        lock (_stateLock)
+        {
+            var catalog = snapshot.Index.Plugins.ToDictionary(
+                entry => entry.Id,
+                StringComparer.OrdinalIgnoreCase);
+            var previousState = CloneState(_state);
+            var changed = false;
+            for (var index = 0; index < _state.Subscriptions.Count; index++)
+            {
+                var record = _state.Subscriptions[index];
+                if (!string.Equals(
+                        record.RepositoryId,
+                        repositoryId,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var available = catalog.TryGetValue(record.PluginId, out var entry) &&
+                                string.Equals(
+                                    entry.Path,
+                                    record.RepositoryPath,
+                                    StringComparison.Ordinal);
+                var updated = record with {
+                    IsAvailable = available,
+                    LastKnownVersion = available
+                        ? entry!.Version
+                        : record.LastKnownVersion
+                };
+                if (updated != record)
+                {
+                    _state.Subscriptions[index] = updated;
+                    changed = true;
+                }
+            }
+
+            if (!changed)
+            {
+                return Result.Success();
+            }
+
+            var saveResult = SaveState();
+            if (saveResult.IsFailure)
+            {
+                _state = previousState;
+            }
+
+            return saveResult;
+        }
+    }
+
+    private PluginSubscriptionState LoadState()
+    {
+        if (!File.Exists(_stateFilePath))
+        {
+            return new PluginSubscriptionState();
+        }
+
+        var result = JsonHelper.LoadFromFile<PluginSubscriptionState>(_stateFilePath);
+        if (result.IsFailure ||
+            result.Value!.SchemaVersion != 1 ||
+            result.Value.Subscriptions == null ||
+            result.Value.Subscriptions.Any(record => !IsValid(record)))
+        {
+            _logService.Warn(
+                nameof(PluginSubscriptionService),
+                "插件仓库订阅文件无效，将使用空状态");
+            return new PluginSubscriptionState();
+        }
+
+        var unique = result.Value.Subscriptions
+            .GroupBy(record => record.PluginId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => Clone(group.First()))
+            .ToList();
+        return new PluginSubscriptionState {
+            SchemaVersion = 1,
+            Subscriptions = unique
+        };
+    }
+
+    private Result SaveState()
+    {
+        var temporaryPath =
+            $"{_stateFilePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            var directory = Path.GetDirectoryName(_stateFilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var saveResult = JsonHelper.SaveToFile(temporaryPath, _state);
+            if (saveResult.IsFailure)
+            {
+                TryDeleteFile(temporaryPath);
+                return saveResult;
+            }
+
+            File.Move(temporaryPath, _stateFilePath, overwrite: true);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            TryDeleteFile(temporaryPath);
+            return Result.Failure(
+                Error.FileSystem(
+                    "PLUGIN_SUBSCRIPTION_SAVE_FAILED",
+                    $"保存插件订阅失败: {ex.Message}",
+                    ex,
+                    _stateFilePath));
+        }
+    }
+
+    private PluginSubscriptionRecord? Find(string pluginId)
+    {
+        return _state.Subscriptions.FirstOrDefault(
+            record => string.Equals(
+                record.PluginId,
+                pluginId,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private Result UpdateSubscription(
+        string pluginId,
+        Func<PluginSubscriptionRecord, PluginSubscriptionRecord> update)
+    {
+        if (!PluginIdValidator.IsValid(pluginId))
+        {
+            return Result.Failure(
+                Error.Validation(
+                    "PLUGIN_SUBSCRIPTION_ID_INVALID",
+                    "插件订阅 ID 无效"));
+        }
+
+        lock (_stateLock)
+        {
+            var existing = Find(pluginId);
+            if (existing == null)
+            {
+                return Result.Failure(
+                    Error.BusinessLogic(
+                        "PLUGIN_SUBSCRIPTION_NOT_FOUND",
+                        $"插件 {pluginId} 尚未订阅"));
+            }
+
+            var previousState = CloneState(_state);
+            _state.Subscriptions[_state.Subscriptions.IndexOf(existing)] =
+                update(existing);
+            var saveResult = SaveState();
+            if (saveResult.IsFailure)
+            {
+                _state = previousState;
+            }
+
+            return saveResult;
+        }
+    }
+
+    private static Error? ValidateSubscription(
+        string repositoryId,
+        PluginRepositoryEntry entry)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryId))
+        {
+            return Error.Validation(
+                "PLUGIN_SUBSCRIPTION_REPOSITORY_INVALID",
+                "插件仓库 ID 不能为空");
+        }
+
+        if (!PluginIdValidator.IsValid(entry.Id) ||
+            !string.Equals(
+                entry.Path,
+                $"{AppConstants.PluginsDirectoryName}/{entry.Id}",
+                StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(entry.Version))
+        {
+            return Error.Validation(
+                "PLUGIN_SUBSCRIPTION_ENTRY_INVALID",
+                "插件仓库条目无效");
+        }
+
+        return null;
+    }
+
+    private static bool IsValid(PluginSubscriptionRecord? record)
+    {
+        return record != null &&
+               !string.IsNullOrWhiteSpace(record.RepositoryId) &&
+               PluginIdValidator.IsValid(record.PluginId) &&
+               string.Equals(
+                   record.RepositoryPath,
+                   $"{AppConstants.PluginsDirectoryName}/{record.PluginId}",
+                   StringComparison.Ordinal) &&
+               !string.IsNullOrWhiteSpace(record.LastKnownVersion) &&
+               (string.IsNullOrWhiteSpace(record.InstalledVersion)
+                   ? string.IsNullOrWhiteSpace(record.InstalledCommit)
+                   : !string.IsNullOrWhiteSpace(record.InstalledCommit));
+    }
+
+    private static PluginSubscriptionRecord Clone(
+        PluginSubscriptionRecord record)
+    {
+        return record with { };
+    }
+
+    private static PluginSubscriptionState CloneState(
+        PluginSubscriptionState state)
+    {
+        return new PluginSubscriptionState {
+            SchemaVersion = state.SchemaVersion,
+            Subscriptions = state.Subscriptions.Select(Clone).ToList()
+        };
+    }
+
+    private static void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch
+        {
+            // 临时文件由系统后续清理。
+        }
+    }
+}

--- a/AkashaNavigator/Services/PluginWriteCoordinator.cs
+++ b/AkashaNavigator/Services/PluginWriteCoordinator.cs
@@ -1,0 +1,37 @@
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 串行化仓库缓存与已安装插件目录的写操作。
+/// </summary>
+public sealed class PluginWriteCoordinator
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public IDisposable Acquire()
+    {
+        _semaphore.Wait();
+        return new Releaser(_semaphore);
+    }
+
+    public async ValueTask<IDisposable> AcquireAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        return new Releaser(_semaphore);
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private SemaphoreSlim? _semaphore;
+
+        public Releaser(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
+        }
+    }
+}

--- a/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
@@ -30,6 +30,8 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     private readonly INotificationService _notificationService;
     private readonly IEventBus _eventBus;
     private readonly IPluginRepositoryService _pluginRepositoryService;
+    private readonly IPluginSubscriptionService _pluginSubscriptionService;
+    private readonly IPluginInstaller _pluginInstaller;
     private readonly IPluginPackageService _pluginPackageService;
     private readonly IConfigService _configService;
     private readonly Dictionary<string, CancellationTokenSource> _downloads =
@@ -89,6 +91,8 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         INotificationService notificationService,
         IEventBus eventBus,
         IPluginRepositoryService pluginRepositoryService,
+        IPluginSubscriptionService pluginSubscriptionService,
+        IPluginInstaller pluginInstaller,
         IPluginPackageService pluginPackageService,
         IConfigService configService)
     {
@@ -97,6 +101,10 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
         _pluginRepositoryService =
             pluginRepositoryService ?? throw new ArgumentNullException(nameof(pluginRepositoryService));
+        _pluginSubscriptionService =
+            pluginSubscriptionService ?? throw new ArgumentNullException(nameof(pluginSubscriptionService));
+        _pluginInstaller =
+            pluginInstaller ?? throw new ArgumentNullException(nameof(pluginInstaller));
         _pluginPackageService =
             pluginPackageService ?? throw new ArgumentNullException(nameof(pluginPackageService));
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
@@ -127,6 +135,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         var initializeResult = await _pluginRepositoryService.InitializeAsync();
         if (initializeResult.IsSuccess)
         {
+            ReconcileSubscriptions(initializeResult.Value!);
             UpdateRepositoryStatus(initializeResult.Value);
             RefreshPluginList();
             return;
@@ -189,11 +198,27 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             return new List<AvailablePluginItemModel>();
         }
 
-        return snapshot.Index.Plugins
+        var items = snapshot.Index.Plugins
             .Select(
                 entry => CreateItem(
                     CreateCatalogEntry(entry),
                     installed.GetValueOrDefault(entry.Id)))
+            .ToList();
+        var catalogIds = snapshot.Index.Plugins
+            .Select(entry => entry.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        items.AddRange(
+            _pluginSubscriptionService
+                .GetSubscriptions()
+                .Where(
+                    subscription =>
+                        !subscription.IsAvailable &&
+                        !catalogIds.Contains(subscription.PluginId))
+                .Select(
+                    subscription => CreateRemovedItem(
+                        subscription,
+                        installed.GetValueOrDefault(subscription.PluginId))));
+        return items
             .OrderBy(item => item.Name, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
     }
@@ -251,6 +276,50 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private void UpdateAllSubscribed()
+    {
+        var updates = _pluginSubscriptionService.GetAvailableUpdates();
+        if (updates.Count == 0)
+        {
+            _notificationService.Show(
+                "已订阅插件均为最新版本",
+                NotificationType.Info);
+            return;
+        }
+
+        var succeeded = 0;
+        var failures = new List<string>();
+        foreach (var update in updates)
+        {
+            var result =
+                _pluginInstaller.InstallOrUpdateRepositoryPlugin(update.PluginId);
+            if (result.IsSuccess)
+            {
+                succeeded++;
+            }
+            else
+            {
+                failures.Add(
+                    $"{update.PluginId}: {result.Error?.Message ?? "未知错误"}");
+            }
+        }
+
+        RefreshPluginList();
+        RefreshRequested?.Invoke(this, EventArgs.Empty);
+        if (failures.Count == 0)
+        {
+            _notificationService.Show(
+                $"已更新 {succeeded} 个订阅插件",
+                NotificationType.Success);
+            return;
+        }
+
+        _notificationService.Show(
+            $"已更新 {succeeded} 个插件，{failures.Count} 个失败：\n{string.Join("\n", failures)}",
+            NotificationType.Warning);
+    }
+
     /// <summary>
     /// 安装插件命令（自动生成 InstallCommand）
     /// </summary>
@@ -259,6 +328,12 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     {
         if (plugin == null)
             return;
+
+        if (plugin.IsRepositoryDistribution)
+        {
+            InstallRepositoryPlugin(plugin);
+            return;
+        }
 
         if (plugin.IsRemote)
         {
@@ -297,7 +372,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     /// </summary>
     public void InstallPackage(string archivePath)
     {
-        var result = _pluginLibrary.InstallPluginPackage(archivePath);
+        var result = _pluginInstaller.InstallPackage(archivePath);
         if (result.IsSuccess)
         {
             _notificationService.Show(
@@ -308,6 +383,65 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         else
         {
             _notificationService.Show($"插件包导入失败: {result.Error?.Message}", NotificationType.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void Subscribe(AvailablePluginItemModel? plugin)
+    {
+        if (plugin == null || !plugin.IsRepositoryDistribution)
+        {
+            return;
+        }
+
+        var entry = FindRepositoryEntry(plugin.Id);
+        if (entry == null)
+        {
+            _notificationService.Show(
+                "插件已不在当前仓库中，无法订阅",
+                NotificationType.Error);
+            return;
+        }
+
+        var result = _pluginSubscriptionService.Subscribe(
+            AppConstants.OfficialPluginRepositoryId,
+            entry);
+        if (result.IsSuccess)
+        {
+            plugin.IsSubscribed = true;
+            _notificationService.Show(
+                $"已订阅插件 \"{plugin.Name}\"",
+                NotificationType.Success);
+        }
+        else
+        {
+            _notificationService.Show(
+                $"订阅失败: {result.Error?.Message}",
+                NotificationType.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void Unsubscribe(AvailablePluginItemModel? plugin)
+    {
+        if (plugin == null)
+        {
+            return;
+        }
+
+        var result = _pluginSubscriptionService.Unsubscribe(plugin.Id);
+        if (result.IsSuccess)
+        {
+            plugin.IsSubscribed = false;
+            _notificationService.Show(
+                $"已取消订阅插件 \"{plugin.Name}\"，已安装文件和配置均已保留",
+                NotificationType.Success);
+        }
+        else
+        {
+            _notificationService.Show(
+                $"取消订阅失败: {result.Error?.Message}",
+                NotificationType.Error);
         }
     }
 
@@ -362,6 +496,9 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             Author = author,
             SourceDirectory = entry.LocalSourceDirectory ?? string.Empty,
             IsRemote = entry.IsRemote,
+            DistributionType = entry.DistributionType,
+            IsRepositoryAvailable = true,
+            IsSubscribed = IsSubscribedToCurrentRepository(entry.Id),
             InstalledVersion = installed?.Version ?? string.Empty,
             InstalledVersionText = installed == null ? "未安装" : $"已安装: v{installed.Version}",
             PackageSizeText = entry.Package == null ? string.Empty : FormatBytes(entry.Package.Size),
@@ -373,6 +510,30 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             SelectedSourceText = entry.IsRemote
                 ? $"下载源：{GetPreferenceDisplayName(_configService.Config.PluginDownloadSourcePreference)}"
                 : string.Empty
+        };
+    }
+
+    private static AvailablePluginItemModel CreateRemovedItem(
+        PluginSubscriptionRecord subscription,
+        InstalledPluginInfo? installed)
+    {
+        return new AvailablePluginItemModel {
+            Id = subscription.PluginId,
+            Name = installed?.Name ?? subscription.PluginId,
+            Version = subscription.LastKnownVersion,
+            Description = installed?.Description ?? "该插件已从仓库中移除",
+            Author = installed?.Author,
+            DistributionType = AppConstants.PluginDistributionRepository,
+            IsRepositoryAvailable = false,
+            IsSubscribed = true,
+            InstalledVersion = installed?.Version ?? string.Empty,
+            InstalledVersionText = installed == null
+                ? "未安装"
+                : $"已安装: v{installed.Version}",
+            HasDescription = true,
+            HasAuthor = !string.IsNullOrWhiteSpace(installed?.Author),
+            IsInstalled = installed != null,
+            HasUpdate = false
         };
     }
 
@@ -435,6 +596,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         }
 
         UpdateRepositoryStatus(result.Value);
+        ReconcileSubscriptions(result.Value!);
         RefreshPluginList();
         _notificationService.Show(
             result.Value!.UsedCache
@@ -468,11 +630,67 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
             Version = entry.Version,
             Description = entry.Description,
             MinHostVersion = entry.MinHostVersion,
+            DistributionType = entry.DistributionType,
             LocalSourceDirectory = isRelease
                 ? null
                 : Path.Combine(_pluginRepositoryService.RepositoryDirectory, entry.Path),
             IsRemote = isRelease
         };
+    }
+
+    private void InstallRepositoryPlugin(AvailablePluginItemModel plugin)
+    {
+        var wasInstalled = plugin.IsInstalled;
+        var result = _pluginInstaller.InstallOrUpdateRepositoryPlugin(plugin.Id);
+        if (result.IsFailure)
+        {
+            _notificationService.Show(
+                $"仓库插件安装失败: {result.Error?.Message}",
+                NotificationType.Error);
+            return;
+        }
+
+        plugin.IsInstalled = true;
+        plugin.IsSubscribed = true;
+        plugin.InstalledVersion = result.Value!.Version;
+        plugin.InstalledVersionText = $"已安装: v{result.Value.Version}";
+        plugin.HasUpdate = false;
+        _notificationService.Show(
+            $"插件 \"{plugin.Name}\" {(wasInstalled ? "更新" : "安装")}成功！",
+            NotificationType.Success);
+        RefreshRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private PluginRepositoryEntry? FindRepositoryEntry(string pluginId)
+    {
+        return _pluginRepositoryService.Current?.Index.Plugins.FirstOrDefault(
+            entry => string.Equals(
+                entry.Id,
+                pluginId,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private bool IsSubscribedToCurrentRepository(string pluginId)
+    {
+        var subscription = _pluginSubscriptionService.GetSubscription(pluginId);
+        return subscription != null &&
+               string.Equals(
+                   subscription.RepositoryId,
+                   AppConstants.OfficialPluginRepositoryId,
+                   StringComparison.Ordinal);
+    }
+
+    private void ReconcileSubscriptions(PluginRepositorySnapshot snapshot)
+    {
+        var result = _pluginSubscriptionService.Reconcile(
+            AppConstants.OfficialPluginRepositoryId,
+            snapshot);
+        if (result.IsFailure)
+        {
+            _notificationService.Show(
+                $"同步插件订阅状态失败: {result.Error?.Message}",
+                NotificationType.Warning);
+        }
     }
 
     private async Task InstallRemoteAsync(AvailablePluginItemModel plugin)

--- a/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
+++ b/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
@@ -56,6 +56,9 @@
             <CheckBox Content="启动时更新仓库" Margin="0,0,12,0"
                       Foreground="#CCC" VerticalAlignment="Center"
                       IsChecked="{Binding AutoUpdateRepository}"/>
+            <CheckBox Content="自动更新已订阅插件" Margin="0,0,12,0"
+                      Foreground="#CCC" VerticalAlignment="Center"
+                      IsChecked="{Binding AutoUpdateSubscribedPlugins}"/>
             <Button Content="保存" Style="{StaticResource ActionButtonStyle}"
                     Margin="0,0,8,0"
                     Command="{Binding SaveRepositorySettingsCommand}"/>
@@ -63,7 +66,10 @@
                     Margin="0,0,8,0"
                     Command="{Binding UpdateRepositoryCommand}"/>
             <Button Content="重置仓库" Style="{StaticResource ActionButtonStyle}"
+                    Margin="0,0,8,0"
                     Command="{Binding ResetRepositoryCommand}"/>
+            <Button Content="一键更新订阅" Style="{StaticResource ActionButtonStyle}"
+                    Command="{Binding UpdateAllSubscribedCommand}"/>
         </WrapPanel>
 
         <!-- 统计信息 -->
@@ -125,6 +131,10 @@
                                                 Visibility="{Binding UpdateTagVisibility}">
                                             <TextBlock Text="可更新" Foreground="#FBBF24" FontSize="11"/>
                                         </Border>
+                                        <Border Grid.Column="1" Style="{StaticResource AvailableTagStyle}"
+                                                Visibility="{Binding RemovedTagVisibility}">
+                                            <TextBlock Text="仓库中已移除" Foreground="#F87171" FontSize="11"/>
+                                        </Border>
                                     </Grid>
 
                                     <!-- 第二行：描述和作者 -->
@@ -134,6 +144,9 @@
                                         <TextBlock Text="{Binding Author, StringFormat='作者: {0}'}"
                                                    Foreground="#666" FontSize="11" Margin="0,4,0,0"
                                                    Visibility="{Binding HasAuthorVisibility}"/>
+                                        <TextBlock Text="已订阅仓库更新"
+                                                   Foreground="#A78BFA" FontSize="11" Margin="0,4,0,0"
+                                                   Visibility="{Binding SubscriptionStatusVisibility}"/>
                                         <StackPanel Orientation="Horizontal" Margin="0,5,0,0"
                                                     Visibility="{Binding RemoteInfoVisibility}">
                                             <TextBlock Text="{Binding PackageSizeText, StringFormat='包大小: {0}'}"
@@ -167,7 +180,18 @@
                                                     Command="{Binding DataContext.CancelDownloadCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding CancelButtonVisibility}"/>
+                                            <Button Content="订阅" Style="{StaticResource ActionButtonStyle}"
+                                                    Margin="8,0,0,0"
+                                                    Command="{Binding DataContext.SubscribeCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Visibility="{Binding SubscribeButtonVisibility}"/>
+                                            <Button Content="取消订阅" Style="{StaticResource ActionButtonStyle}"
+                                                    Margin="8,0,0,0"
+                                                    Command="{Binding DataContext.UnsubscribeCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Visibility="{Binding UnsubscribeButtonVisibility}"/>
                                             <Button Content="卸载" Style="{StaticResource ActionButtonStyle}"
+                                                    Margin="8,0,0,0"
                                                     Command="{Binding DataContext.UninstallCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding UninstallButtonVisibility}"/>


### PR DESCRIPTION
## Summary

- add persistent catalog plugin subscriptions with installed-version, commit, availability, and auto-update state
- add a unified repository installer that validates Manifest v2, adapts it for the current runtime, preserves `savedFiles`, and performs staged atomic replacement with rollback
- serialize repository synchronization, plugin installation/update, and uninstall writes through a shared coordinator
- add plugin-center subscribe/unsubscribe, removed-plugin state, one-click updates, startup auto-update, and local ZIP fallback

## Verification

- `dotnet test --no-restore` — 1280 passed, 32 skipped
- `dotnet build -c Release --no-restore --nologo` — 0 errors (4 pre-existing unused-event warnings)

Part of Phase 3: subscriptions and unified installation.