### PR TITLE
feat(plugins): support release distributions and companions

### DIFF
--- a/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
+++ b/AkashaNavigator.Tests/Architecture/ServiceRegistrationTests.cs
@@ -130,6 +130,15 @@ public class ServiceRegistrationTests
             subscriptions.ImplementationType);
         Assert.Equal(ServiceLifetime.Singleton, installer.Lifetime);
         Assert.Equal(typeof(PluginInstaller), installer.ImplementationType);
+
+        var distributionResolver = services.Single(
+            service =>
+                service.ServiceType ==
+                typeof(IPluginDistributionResolver));
+        Assert.Equal(ServiceLifetime.Singleton, distributionResolver.Lifetime);
+        Assert.Equal(
+            typeof(PluginDistributionResolver),
+            distributionResolver.ImplementationType);
         Assert.Equal(ServiceLifetime.Singleton, writeCoordinator.Lifetime);
     }
 

--- a/AkashaNavigator.Tests/PluginManifestTests.cs
+++ b/AkashaNavigator.Tests/PluginManifestTests.cs
@@ -385,6 +385,9 @@ public class PluginManifestTests
 
         Assert.True(result.IsSuccess, result.ErrorMessage);
         Assert.Equal("worker/win-x64/AkashaAutomation.Worker.exe", result.Manifest!.Companion!.Executable);
+        Assert.Equal(
+            AppConstants.DefaultCompanionShutdownTimeoutMs,
+            result.Manifest.Companion.ShutdownTimeoutMs);
         Assert.True(PluginPermissions.IsHighRiskPermission(PluginPermissions.Companion));
     }
 
@@ -426,6 +429,35 @@ public class PluginManifestTests
 
         Assert.False(validation.IsValid);
         Assert.Contains("permissions", validation.Errors.Keys);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(AppConstants.MaxCompanionShutdownTimeoutMs + 1)]
+    public void CompanionManifest_ShouldRejectUnsafeShutdownTimeout(
+        int shutdownTimeoutMs)
+    {
+        var manifest = new PluginManifest
+        {
+            Id = "automation",
+            Name = "Automation",
+            Version = "1.0.0",
+            Main = "main.js",
+            Permissions = new List<string> {
+                PluginPermissions.Companion
+            },
+            Companion = new CompanionManifest {
+                Executable = "worker/worker.exe",
+                ShutdownTimeoutMs = shutdownTimeoutMs
+            }
+        };
+
+        var validation = manifest.Validate();
+
+        Assert.False(validation.IsValid);
+        Assert.Contains(
+            "companion.shutdownTimeoutMs",
+            validation.Errors.Keys);
     }
 
     [Fact]

--- a/AkashaNavigator.Tests/Services/PluginInstallationTransactionTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallationTransactionTests.cs
@@ -86,7 +86,63 @@ public sealed class PluginInstallationTransactionTests : IDisposable
             "old code",
             File.ReadAllText(
                 Path.Combine(_libraryDirectory, PluginId, "main.js")));
+        Assert.Equal(
+            "old code worker",
+            File.ReadAllText(
+                Path.Combine(
+                    _libraryDirectory,
+                    PluginId,
+                    "runtime",
+                    "worker.exe")));
         Assert.Equal("1.0.0", _library.GetInstalledPluginInfo(PluginId)?.Version);
+    }
+
+    [Fact]
+    public void InstallOrUpdateFromDirectory_WhenCompanionStopFails_PreservesOldPair()
+    {
+        var stopCount = 0;
+        var companionProcessManager = new Mock<ICompanionProcessManager>();
+        companionProcessManager
+            .Setup(manager => manager.StopAsync(
+                PluginId,
+                It.IsAny<CancellationToken>()))
+            .Returns(
+                () => ++stopCount == 1
+                    ? Task.CompletedTask
+                    : Task.FromException(
+                        new TimeoutException("Companion did not stop.")));
+        var library = new PluginLibrary(
+            _libraryDirectory,
+            _indexPath,
+            Path.Combine(_root, "builtin"),
+            companionProcessManager.Object,
+            CreateConsentService());
+        var versionOne = CreateSource("1.0.0", "old code");
+        Assert.True(library.InstallOrUpdateFromDirectory(
+            versionOne,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository).IsSuccess);
+
+        var versionTwo = CreateSource("2.0.0", "new code");
+        var result = library.InstallOrUpdateFromDirectory(
+            versionTwo,
+            Array.Empty<string>(),
+            AppConstants.PluginInstallSourceRepository);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(
+            "old code",
+            File.ReadAllText(
+                Path.Combine(_libraryDirectory, PluginId, "main.js")));
+        Assert.Equal(
+            "old code worker",
+            File.ReadAllText(
+                Path.Combine(
+                    _libraryDirectory,
+                    PluginId,
+                    "runtime",
+                    "worker.exe")));
+        Assert.Equal("1.0.0", library.GetInstalledPluginInfo(PluginId)?.Version);
     }
 
     [Fact]
@@ -131,7 +187,11 @@ public sealed class PluginInstallationTransactionTests : IDisposable
     {
         var source = Path.Combine(_root, $"source-{version}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(source);
+        Directory.CreateDirectory(Path.Combine(source, "runtime"));
         File.WriteAllText(Path.Combine(source, "main.js"), mainContent);
+        File.WriteAllText(
+            Path.Combine(source, "runtime", "worker.exe"),
+            $"{mainContent} worker");
         File.WriteAllText(
             Path.Combine(source, AppConstants.PluginManifestFileName),
             JsonSerializer.Serialize(

--- a/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
@@ -1,9 +1,13 @@
 using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Helpers;
 using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Plugin;
 using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Models.Update;
 using AkashaNavigator.Services;
 using Moq;
 using Xunit;
@@ -129,13 +133,24 @@ public sealed class PluginInstallerTests : IDisposable
     }
 
     [Fact]
-    public void InstallOrUpdateRepositoryPlugin_RejectsUnsupportedDistribution()
+    public void InstallOrUpdateRepositoryPlugin_RejectsReleaseWhenDownloaderIsUnavailable()
     {
         var entry = CreateEntry();
         entry.DistributionType = AppConstants.PluginDistributionRelease;
+        var manifest = CreateManifest();
+        manifest.Distribution = CreateReleaseDistribution();
+        WriteCatalogPlugin(manifest);
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord { PluginId = PluginId }));
         var installer = new PluginInstaller(
             CreateRepositoryService(entry).Object,
-            Mock.Of<IPluginSubscriptionService>(),
+            subscriptions.Object,
             Mock.Of<IPluginLibrary>(),
             () => "1.4.0");
 
@@ -210,6 +225,159 @@ public sealed class PluginInstallerTests : IDisposable
         var subscription = subscriptions.GetSubscription(PluginId);
         Assert.Equal("2.0.0", subscription?.InstalledVersion);
         Assert.Equal(new string('b', 40), subscription?.InstalledCommit);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRepositoryPluginAsync_InstallsValidatedReleasePackage()
+    {
+        var entry = CreateEntry();
+        entry.DistributionType = AppConstants.PluginDistributionRelease;
+        entry.HasBackend = true;
+        var catalogManifest = CreateReleaseManifest();
+        WriteCatalogPlugin(catalogManifest);
+        var packageManifest = CreateReleaseManifest();
+        packageManifest.Distribution.Sha256 = null;
+        packageManifest.Distribution.Size = null;
+        var archivePath = WriteReleaseArchive(packageManifest);
+        PluginPackageInfo? requestedPackage = null;
+        var packageService = new Mock<IPluginPackageService>();
+        packageService
+            .Setup(service => service.DownloadPackageAsync(
+                PluginId,
+                It.IsAny<PluginPackageInfo>(),
+                It.IsAny<IProgress<PluginDownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, PluginPackageInfo,
+                IProgress<PluginDownloadProgress>?, CancellationToken>(
+                (_, package, _, _) => requestedPackage = package)
+            .ReturnsAsync(
+                Result<DownloadedPluginPackage>.Success(
+                    new DownloadedPluginPackage(archivePath, "github")));
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord { PluginId = PluginId }));
+        subscriptions
+            .Setup(service => service.MarkInstalled(
+                PluginId,
+                "1.0.0",
+                new string('b', 40)))
+            .Returns(Result.Success());
+        PluginManifest? installedManifest = null;
+        var library = new Mock<IPluginLibrary>();
+        library
+            .Setup(service => service.InstallOrUpdateFromDirectory(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                AppConstants.PluginInstallSourceRepository))
+            .Callback<string, IReadOnlyList<string>, string>(
+                (directory, savedFiles, _) =>
+                {
+                    installedManifest = PluginManifest.LoadFromFile(
+                        Path.Combine(
+                            directory,
+                            AppConstants.PluginManifestFileName)).Manifest;
+                    Assert.True(
+                        File.Exists(
+                            Path.Combine(
+                                directory,
+                                "runtime",
+                                "worker.exe")));
+                    Assert.Equal(new[] { "data/user.json" }, savedFiles);
+                })
+            .Returns(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = PluginId,
+                        Name = "Sample",
+                        Version = "1.0.0"
+                    }));
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions.Object,
+            library.Object,
+            packageService.Object,
+            () => "1.4.0");
+
+        var result =
+            await installer.InstallOrUpdateRepositoryPluginAsync(PluginId);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        Assert.NotNull(installedManifest?.Companion);
+        Assert.Equal(
+            4321,
+            installedManifest!.Companion!.ShutdownTimeoutMs);
+        Assert.NotNull(requestedPackage);
+        Assert.Equal(1024, requestedPackage!.Size);
+        Assert.Equal(new string('a', 64), requestedPackage.Sha256);
+        Assert.Equal(
+            new[] { "github", "cnb" },
+            requestedPackage.Sources.Select(source => source.Id));
+        Assert.Contains(
+            "/releases/download/sample-plugin-v1.0.0/",
+            requestedPackage.Sources[0].Url);
+        Assert.Contains(
+            "/-/releases/download/sample-plugin-v1.0.0/",
+            requestedPackage.Sources[1].Url);
+        Assert.False(File.Exists(archivePath));
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRepositoryPluginAsync_RejectsReleaseManifestMismatch()
+    {
+        var entry = CreateEntry();
+        entry.DistributionType = AppConstants.PluginDistributionRelease;
+        entry.HasBackend = true;
+        WriteCatalogPlugin(CreateReleaseManifest());
+        var packageManifest = CreateReleaseManifest();
+        packageManifest.Description = "tampered";
+        packageManifest.Distribution.Sha256 = null;
+        packageManifest.Distribution.Size = null;
+        var archivePath = WriteReleaseArchive(packageManifest);
+        var packageService = new Mock<IPluginPackageService>();
+        packageService
+            .Setup(service => service.DownloadPackageAsync(
+                PluginId,
+                It.IsAny<PluginPackageInfo>(),
+                It.IsAny<IProgress<PluginDownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                Result<DownloadedPluginPackage>.Success(
+                    new DownloadedPluginPackage(archivePath, "github")));
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord { PluginId = PluginId }));
+        var library = new Mock<IPluginLibrary>();
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions.Object,
+            library.Object,
+            packageService.Object,
+            () => "1.4.0");
+
+        var result =
+            await installer.InstallOrUpdateRepositoryPluginAsync(PluginId);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(
+            PluginErrorCodes.RepositoryManifestInvalid,
+            result.Error?.Code);
+        library.Verify(
+            service => service.InstallOrUpdateFromDirectory(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>()),
+            Times.Never);
+        Assert.False(File.Exists(archivePath));
     }
 
     public void Dispose()
@@ -301,6 +469,70 @@ public sealed class PluginInstallerTests : IDisposable
                 Type = AppConstants.PluginDistributionRepository
             }
         };
+    }
+
+    private static CatalogPluginDistribution CreateReleaseDistribution()
+    {
+        return new CatalogPluginDistribution {
+            Type = AppConstants.PluginDistributionRelease,
+            Tag = $"{PluginId}-v1.0.0",
+            Asset = $"{PluginId}-1.0.0-win-x64.zip",
+            Sha256 = new string('a', 64),
+            Size = 1024
+        };
+    }
+
+    private static CatalogPluginManifest CreateReleaseManifest()
+    {
+        var manifest = CreateManifest();
+        manifest.Main = "frontend/main.js";
+        manifest.Permissions = new List<string> {
+            PluginPermissions.Companion
+        };
+        manifest.SavedFiles = new List<string> { "data/user.json" };
+        manifest.Distribution = CreateReleaseDistribution();
+        manifest.Backend = new CatalogPluginBackend {
+            Type = AppConstants.CompanionBackendType,
+            Entry = "runtime/worker.exe",
+            ProtocolVersion = AppConstants.CompanionProtocolVersion,
+            Lifetime = AppConstants.CompanionLifetimePlugin,
+            IntegrityLevel = AppConstants.CompanionIntegrityLevelInherit,
+            ShutdownTimeoutMs = 4321
+        };
+        return manifest;
+    }
+
+    private string WriteReleaseArchive(
+        CatalogPluginManifest packageManifest)
+    {
+        var archivePath = Path.Combine(
+            _repositoryDirectory,
+            $"release-{Guid.NewGuid():N}.zip");
+        Directory.CreateDirectory(_repositoryDirectory);
+        using var archive = ZipFile.Open(
+            archivePath,
+            ZipArchiveMode.Create);
+        WriteArchiveEntry(
+            archive,
+            AppConstants.PluginRepositoryManifestFileName,
+            JsonSerializer.Serialize(
+                packageManifest,
+                JsonHelper.WriteOptions));
+        WriteArchiveEntry(archive, "frontend/main.js", "main");
+        WriteArchiveEntry(archive, "runtime/worker.exe", "worker");
+        return archivePath;
+    }
+
+    private static void WriteArchiveEntry(
+        ZipArchive archive,
+        string path,
+        string content)
+    {
+        var entry = archive.CreateEntry(path);
+        using var writer = new StreamWriter(
+            entry.Open(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
     }
 
     private static IPluginPermissionConsentService CreateConsentService()

--- a/AkashaNavigator.Tests/Services/PluginPermissionConsentServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginPermissionConsentServiceTests.cs
@@ -68,6 +68,22 @@ public sealed class PluginPermissionConsentServiceTests
     }
 
     [Fact]
+    public void ChangedShutdownPolicy_ShouldChangePermissionFingerprint()
+    {
+        var manifest = CreateManifest();
+        var original =
+            PluginPermissionConsentService.CreatePermissionFingerprint(
+                manifest);
+
+        manifest.Companion!.ShutdownTimeoutMs++;
+        var changed =
+            PluginPermissionConsentService.CreatePermissionFingerprint(
+                manifest);
+
+        Assert.NotEqual(original, changed);
+    }
+
+    [Fact]
     public void Revoke_ShouldRequireApprovalOnNextEnable()
     {
         using var directory = new TemporaryDirectory();

--- a/AkashaNavigator.Tests/Services/PluginReleaseArchiveExtractorTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginReleaseArchiveExtractorTests.cs
@@ -1,0 +1,140 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using AkashaNavigator.Services;
+using Xunit;
+
+namespace AkashaNavigator.Tests.Services;
+
+public sealed class PluginReleaseArchiveExtractorTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        $"AkashaNavigator.ReleaseArchiveTests.{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Extract_AcceptsSingleTopLevelPluginDirectory()
+    {
+        var archivePath = CreateArchive(
+            ("sample/manifest.json", "{}"),
+            ("sample/frontend/main.js", "main"),
+            ("sample/runtime/worker.exe", "worker"));
+        var extractionRoot = Path.Combine(_root, "extract");
+
+        var pluginDirectory =
+            PluginReleaseArchiveExtractor.Extract(
+                archivePath,
+                extractionRoot);
+
+        Assert.Equal(
+            Path.Combine(extractionRoot, "sample"),
+            pluginDirectory);
+        Assert.True(
+            File.Exists(
+                Path.Combine(
+                    pluginDirectory,
+                    "runtime",
+                    "worker.exe")));
+    }
+
+    [Fact]
+    public void Extract_RejectsPathTraversalWithoutWritingOutsideStaging()
+    {
+        var archivePath = CreateArchive(
+            ("manifest.json", "{}"),
+            ("../escaped.txt", "unsafe"));
+        var extractionRoot = Path.Combine(_root, "extract");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => PluginReleaseArchiveExtractor.Extract(
+                archivePath,
+                extractionRoot));
+
+        Assert.Contains("不安全路径", exception.Message);
+        Assert.False(
+            File.Exists(
+                Path.Combine(_root, "escaped.txt")));
+    }
+
+    [Fact]
+    public void Extract_RejectsWindowsReparsePointEntry()
+    {
+        Directory.CreateDirectory(_root);
+        var archivePath = Path.Combine(_root, "reparse.zip");
+        using (var archive = ZipFile.Open(
+                   archivePath,
+                   ZipArchiveMode.Create))
+        {
+            var manifest = archive.CreateEntry("manifest.json");
+            using (var writer = new StreamWriter(manifest.Open()))
+            {
+                writer.Write("{}");
+            }
+
+            var reparseEntry = archive.CreateEntry("runtime/worker.exe");
+            reparseEntry.ExternalAttributes =
+                (int)FileAttributes.ReparsePoint;
+            using var stream = reparseEntry.Open();
+            stream.WriteByte(1);
+        }
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => PluginReleaseArchiveExtractor.Extract(
+                archivePath,
+                Path.Combine(_root, "extract")));
+
+        Assert.Contains("重解析点", exception.Message);
+    }
+
+    [Fact]
+    public void Extract_RejectsMultipleCatalogManifests()
+    {
+        var archivePath = CreateArchive(
+            ("first/manifest.json", "{}"),
+            ("second/manifest.json", "{}"));
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => PluginReleaseArchiveExtractor.Extract(
+                archivePath,
+                Path.Combine(_root, "extract")));
+
+        Assert.Contains("多个 manifest.json", exception.Message);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private string CreateArchive(
+        params (string Path, string Content)[] files)
+    {
+        Directory.CreateDirectory(_root);
+        var archivePath = Path.Combine(
+            _root,
+            $"{Guid.NewGuid():N}.zip");
+        using var archive = ZipFile.Open(
+            archivePath,
+            ZipArchiveMode.Create);
+        foreach (var file in files)
+        {
+            var entry = archive.CreateEntry(file.Path);
+            using var writer = new StreamWriter(
+                entry.Open(),
+                new UTF8Encoding(
+                    encoderShouldEmitUTF8Identifier: false));
+            writer.Write(file.Content);
+        }
+
+        return archivePath;
+    }
+}

--- a/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
@@ -6,6 +6,7 @@ using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Config;
 using AkashaNavigator.Models.Plugin;
 using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Models.Update;
 using AkashaNavigator.Services;
 using AkashaNavigator.ViewModels.Pages;
 using Moq;
@@ -54,6 +55,13 @@ public sealed class AvailablePluginsPageViewModelTests
         Assert.Equal(
             Path.Combine("C:\\catalog-cache", "plugins/alpha-plugin"),
             alpha.SourceDirectory);
+        var beta = Assert.Single(
+            viewModel.Plugins.Where(
+                plugin => plugin.Id == "beta-plugin"));
+        Assert.True(beta.IsCatalogDistribution);
+        Assert.Equal(
+            Visibility.Visible,
+            beta.SubscribeButtonVisibility);
         packageService.Verify(
             service => service.GetRemoteCatalog(),
             Times.Never);
@@ -119,8 +127,11 @@ public sealed class AvailablePluginsPageViewModelTests
         var repositoryService = CreateRepositoryService(snapshot);
         var installer = new Mock<IPluginInstaller>();
         installer
-            .Setup(service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"))
-            .Returns(
+            .Setup(service => service.InstallOrUpdateRepositoryPluginAsync(
+                "alpha-plugin",
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
                 Result<InstalledPluginInfo>.Success(
                     new InstalledPluginInfo {
                         Id = "alpha-plugin",
@@ -140,8 +151,56 @@ public sealed class AvailablePluginsPageViewModelTests
         Assert.True(plugin.IsSubscribed);
         Assert.False(plugin.HasUpdate);
         installer.Verify(
-            service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"),
+            service => service.InstallOrUpdateRepositoryPluginAsync(
+                "alpha-plugin",
+                null,
+                It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task InstallCommand_UsesCatalogInstallerForReleasePlugin()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        var installer = new Mock<IPluginInstaller>();
+        installer
+            .Setup(service => service.InstallOrUpdateRepositoryPluginAsync(
+                "beta-plugin",
+                It.IsAny<IProgress<PluginDownloadProgress>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = "beta-plugin",
+                        Name = "Beta",
+                        Version = "1.0.0"
+                    }));
+        var legacyPackageService = new Mock<IPluginPackageService>();
+        var viewModel = CreateViewModel(
+            CreateRepositoryService(snapshot).Object,
+            packageService: legacyPackageService.Object,
+            installer: installer.Object);
+        viewModel.RefreshPluginList();
+        var plugin = Assert.Single(
+            viewModel.Plugins.Where(
+                item => item.Id == "beta-plugin"));
+
+        await viewModel.InstallCommand.ExecuteAsync(plugin);
+
+        Assert.True(plugin.IsInstalled);
+        Assert.True(plugin.IsSubscribed);
+        installer.Verify(
+            service => service.InstallOrUpdateRepositoryPluginAsync(
+                "beta-plugin",
+                It.IsAny<IProgress<PluginDownloadProgress>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        legacyPackageService.Verify(
+            service => service.InstallOrUpdateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<PluginDownloadProgress>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -194,7 +253,7 @@ public sealed class AvailablePluginsPageViewModelTests
     }
 
     [Fact]
-    public void UpdateAllSubscribedCommand_InstallsEveryAvailableUpdate()
+    public async Task UpdateAllSubscribedCommand_InstallsEveryAvailableUpdate()
     {
         var snapshot = CreateSnapshot(usedCache: false);
         var subscriptions = CreateSubscriptionService();
@@ -211,8 +270,11 @@ public sealed class AvailablePluginsPageViewModelTests
                 });
         var installer = new Mock<IPluginInstaller>();
         installer
-            .Setup(service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"))
-            .Returns(
+            .Setup(service => service.InstallOrUpdateRepositoryPluginAsync(
+                "alpha-plugin",
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
                 Result<InstalledPluginInfo>.Success(
                     new InstalledPluginInfo {
                         Id = "alpha-plugin",
@@ -224,10 +286,13 @@ public sealed class AvailablePluginsPageViewModelTests
             subscriptionService: subscriptions.Object,
             installer: installer.Object);
 
-        viewModel.UpdateAllSubscribedCommand.Execute(null);
+        await viewModel.UpdateAllSubscribedCommand.ExecuteAsync(null);
 
         installer.Verify(
-            service => service.InstallOrUpdateRepositoryPlugin("alpha-plugin"),
+            service => service.InstallOrUpdateRepositoryPluginAsync(
+                "alpha-plugin",
+                null,
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/AkashaNavigator/App.xaml.cs
+++ b/AkashaNavigator/App.xaml.cs
@@ -271,7 +271,8 @@ public partial class App : System.Windows.Application
                      .Where(item => item.AutoUpdate))
         {
             var updateResult =
-                pluginInstaller.InstallOrUpdateRepositoryPlugin(update.PluginId);
+                await pluginInstaller.InstallOrUpdateRepositoryPluginAsync(
+                    update.PluginId);
             if (updateResult.IsFailure)
             {
                 logService.Warn(

--- a/AkashaNavigator/AppConstants.cs
+++ b/AkashaNavigator/AppConstants.cs
@@ -296,6 +296,12 @@ public static class AppConstants
     public const string OfficialPluginRepositoryCnbUrl =
         "https://cnb.cool/AkashaNavigator/akasha-plugins.git";
 
+    public const string OfficialPluginReleaseGitHubUrlFormat =
+        "https://github.com/ColinXHL/akasha-plugins/releases/download/{0}/{1}";
+
+    public const string OfficialPluginReleaseCnbUrlFormat =
+        "https://cnb.cool/AkashaNavigator/akasha-plugins/-/releases/download/{0}/{1}";
+
     public const string PluginDistributionRepository = "repository";
 
     public const string PluginDistributionRelease = "release";
@@ -307,6 +313,18 @@ public static class AppConstants
     public const string PluginInstallSourceExternal = "external";
 
     public const string PluginInstallSourceMigrated = "migrated";
+
+    public const string CompanionBackendType = "companion-process";
+
+    public const string CompanionLifetimePlugin = "plugin";
+
+    public const string CompanionIntegrityLevelInherit = "inherit";
+
+    public const int CompanionProtocolVersion = 1;
+
+    public const int DefaultCompanionShutdownTimeoutMs = 5000;
+
+    public const int MaxCompanionShutdownTimeoutMs = 60000;
 
     /// <summary>
     /// Notice 中拾取黑名单资源的键。

--- a/AkashaNavigator/Core/Interfaces/IPluginDistributionResolver.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginDistributionResolver.cs
@@ -1,0 +1,16 @@
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Models.Update;
+
+namespace AkashaNavigator.Core.Interfaces;
+
+public interface IPluginDistributionResolver
+{
+    Task<Result<ResolvedPluginDistribution>> ResolveAsync(
+        string pluginId,
+        PluginRepositoryEntry entry,
+        CatalogPluginManifest manifest,
+        string repositorySourceDirectory,
+        IProgress<PluginDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/AkashaNavigator/Core/Interfaces/IPluginInstaller.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginInstaller.cs
@@ -1,5 +1,6 @@
 using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.Update;
 
 namespace AkashaNavigator.Core.Interfaces;
 
@@ -8,6 +9,11 @@ namespace AkashaNavigator.Core.Interfaces;
 /// </summary>
 public interface IPluginInstaller
 {
+    Task<Result<InstalledPluginInfo>> InstallOrUpdateRepositoryPluginAsync(
+        string pluginId,
+        IProgress<PluginDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
     Result<InstalledPluginInfo> InstallOrUpdateRepositoryPlugin(
         string pluginId);
 

--- a/AkashaNavigator/Core/Interfaces/IPluginPackageService.cs
+++ b/AkashaNavigator/Core/Interfaces/IPluginPackageService.cs
@@ -17,6 +17,12 @@ public interface IPluginPackageService
 
     bool IsUpdateAvailable(string pluginId);
 
+    Task<Result<DownloadedPluginPackage>> DownloadPackageAsync(
+        string pluginId,
+        PluginPackageInfo package,
+        IProgress<PluginDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
     Task<Result<InstalledPluginInfo>> InstallOrUpdateAsync(
         string pluginId,
         IProgress<PluginDownloadProgress>? progress = null,

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -90,6 +90,9 @@ public static class ServiceCollectionExtensions
         // PluginSubscriptionService（聚合仓库插件订阅）
         services.AddSingleton<IPluginSubscriptionService, PluginSubscriptionService>();
 
+        // PluginDistributionResolver（将仓库目录或 Release 统一准备为 staging）
+        services.AddSingleton<IPluginDistributionResolver, PluginDistributionResolver>();
+
         // PluginInstaller（Manifest v2 适配与原子安装事务）
         services.AddSingleton<IPluginInstaller, PluginInstaller>();
 

--- a/AkashaNavigator/Models/Plugin/AvailablePluginItemModel.cs
+++ b/AkashaNavigator/Models/Plugin/AvailablePluginItemModel.cs
@@ -125,8 +125,15 @@ namespace AkashaNavigator.Models.Plugin
                 AppConstants.PluginDistributionRepository,
                 StringComparison.Ordinal);
 
+        public bool IsCatalogDistribution =>
+            IsRepositoryDistribution ||
+            string.Equals(
+                DistributionType,
+                AppConstants.PluginDistributionRelease,
+                StringComparison.Ordinal);
+
         private bool CanUseCatalogEntry =>
-            !IsRepositoryDistribution || IsRepositoryAvailable;
+            !IsCatalogDistribution || IsRepositoryAvailable;
 
         public Visibility AvailableTagVisibility =>
             CanUseCatalogEntry && !IsInstalled && !IsDownloading
@@ -144,7 +151,7 @@ namespace AkashaNavigator.Models.Plugin
                 : Visibility.Collapsed;
 
         public Visibility RemovedTagVisibility =>
-            IsRepositoryDistribution && !IsRepositoryAvailable
+            IsCatalogDistribution && !IsRepositoryAvailable
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 
@@ -171,7 +178,7 @@ namespace AkashaNavigator.Models.Plugin
             IsDownloading ? Visibility.Visible : Visibility.Collapsed;
 
         public Visibility SubscribeButtonVisibility =>
-            IsRepositoryDistribution &&
+            IsCatalogDistribution &&
             IsRepositoryAvailable &&
             !IsSubscribed &&
             !IsDownloading
@@ -179,12 +186,12 @@ namespace AkashaNavigator.Models.Plugin
                 : Visibility.Collapsed;
 
         public Visibility UnsubscribeButtonVisibility =>
-            IsRepositoryDistribution && IsSubscribed && !IsDownloading
+            IsCatalogDistribution && IsSubscribed && !IsDownloading
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 
         public Visibility SubscriptionStatusVisibility =>
-            IsRepositoryDistribution && IsSubscribed
+            IsCatalogDistribution && IsSubscribed
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 

--- a/AkashaNavigator/Models/Plugin/PluginManifest.cs
+++ b/AkashaNavigator/Models/Plugin/PluginManifest.cs
@@ -227,12 +227,17 @@ public class PluginManifest
             result.AddError("companion.executable", "伴生进程必须是 EXE 文件");
         }
 
-        if (Companion.ProtocolVersion != 1)
+        if (Companion.ProtocolVersion != AppConstants.CompanionProtocolVersion)
         {
-            result.AddError("companion.protocolVersion", "仅支持 companion 协议版本 1");
+            result.AddError(
+                "companion.protocolVersion",
+                $"仅支持 companion 协议版本 {AppConstants.CompanionProtocolVersion}");
         }
 
-        if (!string.Equals(Companion.Lifetime, "plugin", StringComparison.Ordinal))
+        if (!string.Equals(
+                Companion.Lifetime,
+                AppConstants.CompanionLifetimePlugin,
+                StringComparison.Ordinal))
         {
             result.AddError("companion.lifetime", "companion lifetime 必须是 plugin");
         }
@@ -240,6 +245,15 @@ public class PluginManifest
         if (!Companion.SingleInstance)
         {
             result.AddError("companion.singleInstance", "companion 必须启用单实例");
+        }
+
+        if (Companion.ShutdownTimeoutMs <= 0 ||
+            Companion.ShutdownTimeoutMs >
+            AppConstants.MaxCompanionShutdownTimeoutMs)
+        {
+            result.AddError(
+                "companion.shutdownTimeoutMs",
+                $"companion 关闭超时必须在 1-{AppConstants.MaxCompanionShutdownTimeoutMs} 毫秒之间");
         }
     }
 
@@ -315,11 +329,16 @@ public class CompanionManifest
 {
     public string? Executable { get; set; }
 
-    public int ProtocolVersion { get; set; } = 1;
+    public int ProtocolVersion { get; set; } =
+        AppConstants.CompanionProtocolVersion;
 
-    public string Lifetime { get; set; } = "plugin";
+    public string Lifetime { get; set; } =
+        AppConstants.CompanionLifetimePlugin;
 
     public bool SingleInstance { get; set; } = true;
+
+    public int ShutdownTimeoutMs { get; set; } =
+        AppConstants.DefaultCompanionShutdownTimeoutMs;
 }
 
 /// <summary>

--- a/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
+++ b/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
@@ -63,7 +63,8 @@ public sealed class CatalogPluginManifest
                     Executable = Backend.Entry,
                     ProtocolVersion = Backend.ProtocolVersion,
                     Lifetime = Backend.Lifetime,
-                    SingleInstance = true
+                    SingleInstance = true,
+                    ShutdownTimeoutMs = Backend.ShutdownTimeoutMs
                 },
             DefaultConfig = DefaultConfig == null
                 ? new Dictionary<string, JsonElement>()

--- a/AkashaNavigator/Models/PluginRepository/ResolvedPluginDistribution.cs
+++ b/AkashaNavigator/Models/PluginRepository/ResolvedPluginDistribution.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace AkashaNavigator.Models.PluginRepository;
+
+public sealed class ResolvedPluginDistribution : IDisposable
+{
+    private readonly string _cleanupDirectory;
+
+    public ResolvedPluginDistribution(
+        string sourceDirectory,
+        string? cleanupDirectory = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceDirectory);
+        SourceDirectory = Path.GetFullPath(sourceDirectory);
+        _cleanupDirectory = Path.GetFullPath(
+            cleanupDirectory ?? sourceDirectory);
+    }
+
+    public string SourceDirectory { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_cleanupDirectory))
+            {
+                Directory.Delete(_cleanupDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // staging 目录由系统后续清理。
+        }
+    }
+}

--- a/AkashaNavigator/Models/Update/DownloadedPluginPackage.cs
+++ b/AkashaNavigator/Models/Update/DownloadedPluginPackage.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+
+namespace AkashaNavigator.Models.Update;
+
+/// <summary>
+/// 已校验的临时插件包。释放对象时删除临时文件。
+/// </summary>
+public sealed class DownloadedPluginPackage : IDisposable
+{
+    public DownloadedPluginPackage(string filePath, string sourceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        FilePath = Path.GetFullPath(filePath);
+        SourceId = sourceId;
+    }
+
+    public string FilePath { get; }
+
+    public string SourceId { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                File.Delete(FilePath);
+            }
+        }
+        catch
+        {
+            // 临时下载文件由系统后续清理。
+        }
+    }
+}

--- a/AkashaNavigator/Services/Companion/CompanionSession.cs
+++ b/AkashaNavigator/Services/Companion/CompanionSession.cs
@@ -7,12 +7,11 @@ namespace AkashaNavigator.Services.Companion;
 
 internal sealed class CompanionSession : IAsyncDisposable
 {
-    private static readonly TimeSpan GracefulShutdownTimeout = TimeSpan.FromSeconds(3);
-
     private readonly Process _process;
     private readonly NamedPipeServerStream _pipe;
     private readonly CompanionJobObject _jobObject;
     private readonly CompanionRequestMultiplexer _requests;
+    private readonly TimeSpan _gracefulShutdownTimeout;
     private int _stopping;
 
     public CompanionSession(
@@ -20,13 +19,15 @@ internal sealed class CompanionSession : IAsyncDisposable
         Process process,
         NamedPipeServerStream pipe,
         CompanionJobObject jobObject,
-        CompanionFraming framing)
+        CompanionFraming framing,
+        TimeSpan gracefulShutdownTimeout)
     {
         PluginId = pluginId;
         _process = process;
         _pipe = pipe;
         _jobObject = jobObject;
         _requests = new CompanionRequestMultiplexer(pipe, framing);
+        _gracefulShutdownTimeout = gracefulShutdownTimeout;
     }
 
     public string PluginId { get; }
@@ -73,10 +74,11 @@ internal sealed class CompanionSession : IAsyncDisposable
             return;
         }
 
+        var shutdownStopwatch = Stopwatch.StartNew();
         try
         {
             using var shutdownCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            shutdownCancellation.CancelAfter(GracefulShutdownTimeout);
+            shutdownCancellation.CancelAfter(_gracefulShutdownTimeout);
 
             try
             {
@@ -103,8 +105,19 @@ internal sealed class CompanionSession : IAsyncDisposable
             {
                 if (!_process.HasExited)
                 {
-                    using var exitCancellation = new CancellationTokenSource(GracefulShutdownTimeout);
-                    await _process.WaitForExitAsync(exitCancellation.Token).ConfigureAwait(false);
+                    var remaining =
+                        _gracefulShutdownTimeout -
+                        shutdownStopwatch.Elapsed;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        TryKillProcessTree();
+                    }
+                    else
+                    {
+                        using var exitCancellation =
+                            new CancellationTokenSource(remaining);
+                        await _process.WaitForExitAsync(exitCancellation.Token).ConfigureAwait(false);
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -132,7 +145,8 @@ internal sealed class CompanionSession : IAsyncDisposable
         try
         {
             _process.Kill(entireProcessTree: true);
-            _process.WaitForExit((int)GracefulShutdownTimeout.TotalMilliseconds);
+            _process.WaitForExit(
+                (int)_gracefulShutdownTimeout.TotalMilliseconds);
         }
         catch
         {

--- a/AkashaNavigator/Services/CompanionProcessManager.cs
+++ b/AkashaNavigator/Services/CompanionProcessManager.cs
@@ -63,6 +63,7 @@ public sealed class CompanionProcessManager : ICompanionProcessManager
                     pluginId,
                     executable,
                     manifest.ProtocolVersion,
+                    manifest.ShutdownTimeoutMs,
                     cancellationToken)
                 .ConfigureAwait(false);
 
@@ -185,6 +186,7 @@ public sealed class CompanionProcessManager : ICompanionProcessManager
         string pluginId,
         string executable,
         int protocolVersion,
+        int shutdownTimeoutMs,
         CancellationToken cancellationToken)
     {
         var pipeName = $"akasha-{Environment.ProcessId}-{Guid.NewGuid():N}";
@@ -256,7 +258,13 @@ public sealed class CompanionProcessManager : ICompanionProcessManager
                 }
             }
 
-            var session = new CompanionSession(pluginId, process, pipe, jobObject, _framing);
+            var session = new CompanionSession(
+                pluginId,
+                process,
+                pipe,
+                jobObject,
+                _framing,
+                TimeSpan.FromMilliseconds(shutdownTimeoutMs));
             process = null;
             pipe = null;
             jobObject = null;

--- a/AkashaNavigator/Services/PluginDistributionResolver.cs
+++ b/AkashaNavigator/Services/PluginDistributionResolver.cs
@@ -1,0 +1,203 @@
+using System.IO;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Common;
+using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Models.Update;
+
+namespace AkashaNavigator.Services;
+
+public sealed class PluginDistributionResolver : IPluginDistributionResolver
+{
+    private readonly IPluginPackageService? _pluginPackageService;
+
+    public PluginDistributionResolver(
+        IPluginPackageService pluginPackageService)
+    {
+        _pluginPackageService =
+            pluginPackageService ??
+            throw new ArgumentNullException(nameof(pluginPackageService));
+    }
+
+    private PluginDistributionResolver()
+    {
+    }
+
+    internal static PluginDistributionResolver CreateUnavailable() => new();
+
+    public async Task<Result<ResolvedPluginDistribution>> ResolveAsync(
+        string pluginId,
+        PluginRepositoryEntry entry,
+        CatalogPluginManifest manifest,
+        string repositorySourceDirectory,
+        IProgress<PluginDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stagingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"AkashaNavigator.PluginDistribution.{pluginId}.{Guid.NewGuid():N}");
+        var handedOff = false;
+        try
+        {
+            if (string.Equals(
+                    entry.DistributionType,
+                    AppConstants.PluginDistributionRepository,
+                    StringComparison.Ordinal))
+            {
+                CopyDirectorySecure(
+                    repositorySourceDirectory,
+                    stagingDirectory);
+                var resolved = new ResolvedPluginDistribution(
+                    stagingDirectory);
+                handedOff = true;
+                return Result<ResolvedPluginDistribution>.Success(resolved);
+            }
+
+            if (!string.Equals(
+                    entry.DistributionType,
+                    AppConstants.PluginDistributionRelease,
+                    StringComparison.Ordinal) ||
+                _pluginPackageService == null)
+            {
+                return Result<ResolvedPluginDistribution>.Failure(
+                    Error.Plugin(
+                        PluginErrorCodes.DistributionUnsupported,
+                        "插件分发类型不受支持或 Release 下载服务不可用",
+                        pluginId: pluginId));
+            }
+
+            var downloadResult =
+                await _pluginPackageService.DownloadPackageAsync(
+                        pluginId,
+                        CreateReleasePackage(manifest),
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            if (downloadResult.IsFailure)
+            {
+                return Result<ResolvedPluginDistribution>.Failure(
+                    downloadResult.Error!);
+            }
+
+            using var download = downloadResult.Value!;
+            var pluginDirectory = PluginReleaseArchiveExtractor.Extract(
+                download.FilePath,
+                stagingDirectory);
+            var releaseResolved = new ResolvedPluginDistribution(
+                pluginDirectory,
+                stagingDirectory);
+            handedOff = true;
+            return Result<ResolvedPluginDistribution>.Success(
+                releaseResolved);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return Result<ResolvedPluginDistribution>.Failure(
+                Error.Plugin(
+                    PluginErrorCodes.RemoteDownloadCanceled,
+                    "插件分发准备已取消",
+                    ex,
+                    pluginId));
+        }
+        catch (Exception ex)
+        {
+            return Result<ResolvedPluginDistribution>.Failure(
+                Error.FileSystem(
+                    PluginErrorCodes.InstallTransactionFailed,
+                    $"准备插件分发内容失败: {ex.Message}",
+                    ex,
+                    repositorySourceDirectory));
+        }
+        finally
+        {
+            if (!handedOff)
+            {
+                TryDeleteDirectory(stagingDirectory);
+            }
+        }
+    }
+
+    private static PluginPackageInfo CreateReleasePackage(
+        CatalogPluginManifest manifest)
+    {
+        var tag = Uri.EscapeDataString(manifest.Distribution.Tag!);
+        var asset = Uri.EscapeDataString(manifest.Distribution.Asset!);
+        return new PluginPackageInfo {
+            FileName = manifest.Distribution.Asset!,
+            Size = manifest.Distribution.Size!.Value,
+            Sha256 = manifest.Distribution.Sha256!,
+            Sources = new List<DownloadSourceInfo> {
+                new() {
+                    Id = "github",
+                    Url = string.Format(
+                        AppConstants.OfficialPluginReleaseGitHubUrlFormat,
+                        tag,
+                        asset)
+                },
+                new() {
+                    Id = "cnb",
+                    Url = string.Format(
+                        AppConstants.OfficialPluginReleaseCnbUrlFormat,
+                        tag,
+                        asset)
+                }
+            }
+        };
+    }
+
+    private static void CopyDirectorySecure(
+        string sourceDirectory,
+        string targetDirectory)
+    {
+        var source = new DirectoryInfo(sourceDirectory);
+        if (!source.Exists)
+        {
+            throw new DirectoryNotFoundException(sourceDirectory);
+        }
+
+        if ((source.Attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidDataException("插件目录不能是重解析点");
+        }
+
+        Directory.CreateDirectory(targetDirectory);
+        foreach (var file in source.EnumerateFiles())
+        {
+            if ((file.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException($"插件包含重解析文件: {file.Name}");
+            }
+
+            file.CopyTo(
+                Path.Combine(targetDirectory, file.Name),
+                overwrite: true);
+        }
+
+        foreach (var directory in source.EnumerateDirectories())
+        {
+            if ((directory.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException(
+                    $"插件包含重解析目录: {directory.Name}");
+            }
+
+            CopyDirectorySecure(
+                directory.FullName,
+                Path.Combine(targetDirectory, directory.Name));
+        }
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // staging 目录由系统后续清理。
+        }
+    }
+}

--- a/AkashaNavigator/Services/PluginInstaller.cs
+++ b/AkashaNavigator/Services/PluginInstaller.cs
@@ -1,10 +1,13 @@
 using System.IO;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Helpers;
 using AkashaNavigator.Models.Common;
 using AkashaNavigator.Models.Plugin;
 using AkashaNavigator.Models.PluginRepository;
+using AkashaNavigator.Models.Update;
 
 namespace AkashaNavigator.Services;
 
@@ -16,19 +19,22 @@ public sealed class PluginInstaller : IPluginInstaller
     private readonly IPluginRepositoryService _repositoryService;
     private readonly IPluginSubscriptionService _subscriptionService;
     private readonly IPluginLibrary _pluginLibrary;
+    private readonly IPluginDistributionResolver _distributionResolver;
     private readonly ILogService? _logService;
     private readonly Func<string> _hostVersionProvider;
-    private readonly object _installLock = new();
+    private readonly SemaphoreSlim _installGate = new(1, 1);
 
     public PluginInstaller(
         IPluginRepositoryService repositoryService,
         IPluginSubscriptionService subscriptionService,
         IPluginLibrary pluginLibrary,
+        IPluginDistributionResolver distributionResolver,
         ILogService logService)
         : this(
             repositoryService,
             subscriptionService,
             pluginLibrary,
+            distributionResolver,
             GetCurrentHostVersion,
             logService)
     {
@@ -43,6 +49,23 @@ public sealed class PluginInstaller : IPluginInstaller
             repositoryService,
             subscriptionService,
             pluginLibrary,
+            PluginDistributionResolver.CreateUnavailable(),
+            hostVersionProvider,
+            null)
+    {
+    }
+
+    internal PluginInstaller(
+        IPluginRepositoryService repositoryService,
+        IPluginSubscriptionService subscriptionService,
+        IPluginLibrary pluginLibrary,
+        IPluginPackageService pluginPackageService,
+        Func<string> hostVersionProvider)
+        : this(
+            repositoryService,
+            subscriptionService,
+            pluginLibrary,
+            new PluginDistributionResolver(pluginPackageService),
             hostVersionProvider,
             null)
     {
@@ -52,6 +75,7 @@ public sealed class PluginInstaller : IPluginInstaller
         IPluginRepositoryService repositoryService,
         IPluginSubscriptionService subscriptionService,
         IPluginLibrary pluginLibrary,
+        IPluginDistributionResolver distributionResolver,
         Func<string> hostVersionProvider,
         ILogService? logService)
     {
@@ -60,6 +84,9 @@ public sealed class PluginInstaller : IPluginInstaller
         _subscriptionService =
             subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
         _pluginLibrary = pluginLibrary ?? throw new ArgumentNullException(nameof(pluginLibrary));
+        _distributionResolver =
+            distributionResolver ??
+            throw new ArgumentNullException(nameof(distributionResolver));
         _hostVersionProvider =
             hostVersionProvider ?? throw new ArgumentNullException(nameof(hostVersionProvider));
         _logService = logService;
@@ -67,6 +94,17 @@ public sealed class PluginInstaller : IPluginInstaller
 
     public Result<InstalledPluginInfo> InstallOrUpdateRepositoryPlugin(
         string pluginId)
+    {
+        return InstallOrUpdateRepositoryPluginAsync(pluginId)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    public async Task<Result<InstalledPluginInfo>>
+        InstallOrUpdateRepositoryPluginAsync(
+            string pluginId,
+            IProgress<PluginDownloadProgress>? progress = null,
+            CancellationToken cancellationToken = default)
     {
         if (!PluginIdValidator.IsValid(pluginId))
         {
@@ -76,22 +114,39 @@ public sealed class PluginInstaller : IPluginInstaller
                     "插件 ID 无效"));
         }
 
-        lock (_installLock)
+        await _installGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return InstallOrUpdateRepositoryPluginCore(pluginId);
+            return await InstallOrUpdateRepositoryPluginCoreAsync(
+                    pluginId,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _installGate.Release();
         }
     }
 
     public Result<InstalledPluginInfo> InstallPackage(string archivePath)
     {
-        lock (_installLock)
+        _installGate.Wait();
+        try
         {
             return _pluginLibrary.InstallPluginPackage(archivePath);
         }
+        finally
+        {
+            _installGate.Release();
+        }
     }
 
-    private Result<InstalledPluginInfo> InstallOrUpdateRepositoryPluginCore(
-        string pluginId)
+    private async Task<Result<InstalledPluginInfo>>
+        InstallOrUpdateRepositoryPluginCoreAsync(
+            string pluginId,
+            IProgress<PluginDownloadProgress>? progress,
+            CancellationToken cancellationToken)
     {
         var snapshot = _repositoryService.Current;
         var entry = snapshot?.Index.Plugins.FirstOrDefault(
@@ -108,18 +163,6 @@ public sealed class PluginInstaller : IPluginInstaller
                     pluginId: pluginId));
         }
 
-        if (!string.Equals(
-                entry.DistributionType,
-                AppConstants.PluginDistributionRepository,
-                StringComparison.Ordinal))
-        {
-            return Result<InstalledPluginInfo>.Failure(
-                Error.Plugin(
-                    PluginErrorCodes.DistributionUnsupported,
-                    $"当前阶段尚不支持 {entry.DistributionType} 分发",
-                    pluginId: pluginId));
-        }
-
         var sourceDirectory = GetContainedPluginDirectory(
             _repositoryService.RepositoryDirectory,
             entry);
@@ -133,7 +176,15 @@ public sealed class PluginInstaller : IPluginInstaller
         }
 
         var manifest = manifestResult.Value!;
-        var validation = ValidateManifest(entry, manifest, sourceDirectory);
+        var isRelease = string.Equals(
+            entry.DistributionType,
+            AppConstants.PluginDistributionRelease,
+            StringComparison.Ordinal);
+        var validation = ValidateManifest(
+            entry,
+            manifest,
+            sourceDirectory,
+            validatePayload: !isRelease);
         if (validation != null)
         {
             return Result<InstalledPluginInfo>.Failure(validation);
@@ -147,16 +198,57 @@ public sealed class PluginInstaller : IPluginInstaller
             return Result<InstalledPluginInfo>.Failure(subscriptionResult.Error!);
         }
 
-        var preparationDirectory = Path.Combine(
-            Path.GetTempPath(),
-            $"AkashaNavigator.RepositoryPlugin.{pluginId}.{Guid.NewGuid():N}");
         try
         {
-            CopyDirectorySecure(sourceDirectory, preparationDirectory);
+            var distributionResult =
+                await _distributionResolver.ResolveAsync(
+                        pluginId,
+                        entry,
+                        manifest,
+                        sourceDirectory,
+                        progress,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            if (distributionResult.IsFailure)
+            {
+                return Result<InstalledPluginInfo>.Failure(
+                    distributionResult.Error!);
+            }
+
+            using var distribution = distributionResult.Value!;
+            var installSourceDirectory = distribution.SourceDirectory;
+            if (isRelease)
+            {
+                var packageManifestResult =
+                    JsonHelper.LoadFromFile<CatalogPluginManifest>(
+                        Path.Combine(
+                            installSourceDirectory,
+                            AppConstants.PluginRepositoryManifestFileName));
+                if (packageManifestResult.IsFailure)
+                {
+                    return Result<InstalledPluginInfo>.Failure(
+                        packageManifestResult.Error!);
+                }
+
+                var packageManifest = packageManifestResult.Value!;
+                var packageValidation = ValidateReleasePackageManifest(
+                    entry,
+                    manifest,
+                    packageManifest,
+                    installSourceDirectory);
+                if (packageValidation != null)
+                {
+                    return Result<InstalledPluginInfo>.Failure(
+                        packageValidation);
+                }
+
+                manifest = packageManifest;
+            }
+
             var runtimeManifest = manifest.ToRuntimeManifest();
             var saveResult = JsonHelper.SaveToFile(
                 Path.Combine(
-                    preparationDirectory,
+                    installSourceDirectory,
                     AppConstants.PluginManifestFileName),
                 runtimeManifest);
             if (saveResult.IsFailure)
@@ -165,7 +257,7 @@ public sealed class PluginInstaller : IPluginInstaller
             }
 
             var installResult = _pluginLibrary.InstallOrUpdateFromDirectory(
-                preparationDirectory,
+                installSourceDirectory,
                 manifest.SavedFiles,
                 AppConstants.PluginInstallSourceRepository);
             if (installResult.IsFailure)
@@ -196,16 +288,14 @@ public sealed class PluginInstaller : IPluginInstaller
                     ex,
                     sourceDirectory));
         }
-        finally
-        {
-            TryDeleteDirectory(preparationDirectory);
-        }
     }
 
     private Error? ValidateManifest(
         PluginRepositoryEntry entry,
         CatalogPluginManifest manifest,
-        string sourceDirectory)
+        string sourceDirectory,
+        bool validatePayload,
+        bool requireReleaseIntegrity = true)
     {
         if (manifest.ManifestVersion != 2 ||
             !string.Equals(manifest.Id, entry.Id, StringComparison.Ordinal) ||
@@ -232,11 +322,34 @@ public sealed class PluginInstaller : IPluginInstaller
             manifest.Distribution == null ||
             !string.Equals(
                 manifest.Distribution.Type,
-                AppConstants.PluginDistributionRepository,
+                entry.DistributionType,
                 StringComparison.Ordinal) ||
-            manifest.Backend != null)
+            (entry.DistributionType != AppConstants.PluginDistributionRepository &&
+             entry.DistributionType != AppConstants.PluginDistributionRelease) ||
+            entry.HasBackend != (manifest.Backend != null))
         {
             return InvalidManifest(entry.Id, "Manifest v2 与 repo.json 不一致");
+        }
+
+        if (entry.DistributionType == AppConstants.PluginDistributionRepository &&
+            manifest.Backend != null)
+        {
+            return InvalidManifest(
+                entry.Id,
+                "带后端插件必须使用 Release 分发");
+        }
+
+        if (entry.DistributionType == AppConstants.PluginDistributionRelease)
+        {
+            var distributionError = ValidateReleaseDistribution(
+                entry.Id,
+                entry.Version,
+                manifest.Distribution,
+                requireReleaseIntegrity);
+            if (distributionError != null)
+            {
+                return distributionError;
+            }
         }
 
         if (PluginLibrary.CompareVersions(
@@ -258,18 +371,55 @@ public sealed class PluginInstaller : IPluginInstaller
             return InvalidManifest(entry.Id, "插件权限声明无效");
         }
 
-        if (!ValidateRequiredFile(sourceDirectory, manifest.Main) ||
-            (!string.IsNullOrWhiteSpace(manifest.Settings) &&
-             !ValidateRequiredFile(sourceDirectory, manifest.Settings)))
+        if (manifest.Backend != null &&
+            (!manifest.Permissions.Contains(
+                 PluginPermissions.Companion,
+                 StringComparer.Ordinal) ||
+             !string.Equals(
+                 manifest.Backend.Type,
+                 AppConstants.CompanionBackendType,
+                 StringComparison.Ordinal) ||
+             !IsSafeRelativePath(manifest.Backend.Entry) ||
+             !string.Equals(
+                 Path.GetExtension(manifest.Backend.Entry),
+                 ".exe",
+                 StringComparison.OrdinalIgnoreCase) ||
+             manifest.Backend.ProtocolVersion !=
+             AppConstants.CompanionProtocolVersion ||
+             !string.Equals(
+                 manifest.Backend.Lifetime,
+                 AppConstants.CompanionLifetimePlugin,
+                 StringComparison.Ordinal) ||
+             !string.Equals(
+                 manifest.Backend.IntegrityLevel,
+                 AppConstants.CompanionIntegrityLevelInherit,
+                 StringComparison.Ordinal) ||
+             manifest.Backend.ShutdownTimeoutMs <= 0 ||
+             manifest.Backend.ShutdownTimeoutMs >
+             AppConstants.MaxCompanionShutdownTimeoutMs))
         {
-            return InvalidManifest(entry.Id, "插件入口或设置文件不存在");
+            return InvalidManifest(entry.Id, "插件后端声明无效");
+        }
+
+        if (validatePayload &&
+            (!ValidateRequiredFile(sourceDirectory, manifest.Main) ||
+             (!string.IsNullOrWhiteSpace(manifest.Settings) &&
+              !ValidateRequiredFile(sourceDirectory, manifest.Settings)) ||
+             (manifest.Backend != null &&
+              !ValidateRequiredFile(
+                  sourceDirectory,
+                  manifest.Backend.Entry))))
+        {
+            return InvalidManifest(
+                entry.Id,
+                "插件入口、设置文件或后端可执行文件不存在");
         }
 
         if (manifest.Library == null ||
             manifest.Library.Distinct(StringComparer.Ordinal).Count() !=
             manifest.Library.Count ||
-            manifest.Library.Any(
-                path => !ValidateRequiredDirectory(sourceDirectory, path)))
+            (validatePayload && manifest.Library.Any(
+                path => !ValidateRequiredDirectory(sourceDirectory, path))))
         {
             return InvalidManifest(entry.Id, "插件 library 目录无效");
         }
@@ -311,6 +461,99 @@ public sealed class PluginInstaller : IPluginInstaller
         return runtimeValidation.IsValid
             ? null
             : InvalidManifest(entry.Id, "转换后的运行时清单无效");
+    }
+
+    private Error? ValidateReleasePackageManifest(
+        PluginRepositoryEntry entry,
+        CatalogPluginManifest catalogManifest,
+        CatalogPluginManifest packageManifest,
+        string packageDirectory)
+    {
+        var validation = ValidateManifest(
+            entry,
+            packageManifest,
+            packageDirectory,
+            validatePayload: true,
+            requireReleaseIntegrity: false);
+        if (validation != null)
+        {
+            return validation;
+        }
+
+        if (packageManifest.Distribution == null ||
+            catalogManifest.Distribution == null ||
+            (!string.IsNullOrWhiteSpace(
+                 packageManifest.Distribution.Sha256) &&
+             !string.Equals(
+                 packageManifest.Distribution.Sha256,
+                 catalogManifest.Distribution.Sha256,
+                 StringComparison.OrdinalIgnoreCase)) ||
+            (packageManifest.Distribution.Size.HasValue &&
+             packageManifest.Distribution.Size !=
+             catalogManifest.Distribution.Size))
+        {
+            return InvalidManifest(
+                entry.Id,
+                "Release 包内 manifest 的完整性元数据与 catalog 不一致");
+        }
+
+        packageManifest.Distribution.Sha256 =
+            catalogManifest.Distribution.Sha256;
+        packageManifest.Distribution.Size =
+            catalogManifest.Distribution.Size;
+        var catalogJson = JsonSerializer.Serialize(
+            catalogManifest,
+            JsonHelper.WriteOptions);
+        var packageJson = JsonSerializer.Serialize(
+            packageManifest,
+            JsonHelper.WriteOptions);
+        return JsonNode.DeepEquals(
+            JsonNode.Parse(catalogJson),
+            JsonNode.Parse(packageJson))
+            ? null
+            : InvalidManifest(
+                entry.Id,
+                "Release 包内 manifest 与 catalog 不一致");
+    }
+
+    private static Error? ValidateReleaseDistribution(
+        string pluginId,
+        string version,
+        CatalogPluginDistribution distribution,
+        bool requireIntegrity)
+    {
+        var expectedTag = $"{pluginId}-v{version}";
+        var expectedAsset = $"{pluginId}-{version}-win-x64.zip";
+        if (!string.Equals(
+                distribution.Tag,
+                expectedTag,
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                distribution.Asset,
+                expectedAsset,
+                StringComparison.Ordinal) ||
+            (requireIntegrity &&
+             (!IsSha256(distribution.Sha256) ||
+              distribution.Size is null or <= 0)) ||
+            (!string.IsNullOrWhiteSpace(distribution.Sha256) &&
+             !IsSha256(distribution.Sha256)) ||
+            (distribution.Size.HasValue && distribution.Size <= 0))
+        {
+            return InvalidManifest(
+                pluginId,
+                "Release 标签、资源名或完整性元数据无效");
+        }
+
+        return null;
+    }
+
+    private static bool IsSha256(string? value)
+    {
+        return value is { Length: 64 } &&
+               value.All(
+                   character =>
+                       character is >= '0' and <= '9' or
+                           >= 'a' and <= 'f');
     }
 
     private static bool ValidateRequiredFile(
@@ -390,45 +633,6 @@ public sealed class PluginInstaller : IPluginInstaller
         return candidate;
     }
 
-    private static void CopyDirectorySecure(
-        string sourceDirectory,
-        string targetDirectory)
-    {
-        var source = new DirectoryInfo(sourceDirectory);
-        if (!source.Exists)
-        {
-            throw new DirectoryNotFoundException(sourceDirectory);
-        }
-
-        if ((source.Attributes & FileAttributes.ReparsePoint) != 0)
-        {
-            throw new InvalidDataException("插件目录不能是重解析点");
-        }
-
-        Directory.CreateDirectory(targetDirectory);
-        foreach (var file in source.EnumerateFiles())
-        {
-            if ((file.Attributes & FileAttributes.ReparsePoint) != 0)
-            {
-                throw new InvalidDataException($"插件包含重解析文件: {file.Name}");
-            }
-
-            file.CopyTo(Path.Combine(targetDirectory, file.Name), overwrite: true);
-        }
-
-        foreach (var directory in source.EnumerateDirectories())
-        {
-            if ((directory.Attributes & FileAttributes.ReparsePoint) != 0)
-            {
-                throw new InvalidDataException($"插件包含重解析目录: {directory.Name}");
-            }
-
-            CopyDirectorySecure(
-                directory.FullName,
-                Path.Combine(targetDirectory, directory.Name));
-        }
-    }
-
     private static Error InvalidManifest(
         string pluginId,
         string message)
@@ -456,18 +660,4 @@ public sealed class PluginInstaller : IPluginInstaller
         return assembly.GetName().Version?.ToString(3) ?? AppConstants.Version;
     }
 
-    private static void TryDeleteDirectory(string directory)
-    {
-        try
-        {
-            if (Directory.Exists(directory))
-            {
-                Directory.Delete(directory, recursive: true);
-            }
-        }
-        catch
-        {
-            // 准备目录由系统后续清理。
-        }
-    }
 }

--- a/AkashaNavigator/Services/PluginPackageService.cs
+++ b/AkashaNavigator/Services/PluginPackageService.cs
@@ -141,15 +141,55 @@ public sealed class PluginPackageService : IPluginPackageService
                     pluginId: pluginId));
         }
 
+        var downloadResult = await DownloadPackageAsync(
+            pluginId,
+            remote.Package,
+            progress,
+            cancellationToken);
+        if (downloadResult.IsFailure)
+        {
+            return Result<InstalledPluginInfo>.Failure(downloadResult.Error!);
+        }
+
+        using var download = downloadResult.Value!;
+        return _pluginLibrary.InstallPluginPackage(download.FilePath);
+    }
+
+    public async Task<Result<DownloadedPluginPackage>> DownloadPackageAsync(
+        string pluginId,
+        PluginPackageInfo package,
+        IProgress<PluginDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!PluginIdValidator.IsValid(pluginId) ||
+            package == null ||
+            string.IsNullOrWhiteSpace(package.FileName) ||
+            !string.Equals(
+                Path.GetFileName(package.FileName),
+                package.FileName,
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                Path.GetExtension(package.FileName),
+                ".zip",
+                StringComparison.OrdinalIgnoreCase) ||
+            package.Size <= 0 ||
+            !IsSha256(package.Sha256))
+        {
+            return Result<DownloadedPluginPackage>.Failure(
+                Error.Validation(
+                    PluginErrorCodes.RemotePackageNotFound,
+                    "插件 Release 包元数据无效"));
+        }
+
         Result<IReadOnlyList<DownloadSourceInfo>> sourcesResult;
         try
         {
             sourcesResult =
-                await _downloadSourceSelector.GetOrderedSourcesAsync(remote.Package, cancellationToken);
+                await _downloadSourceSelector.GetOrderedSourcesAsync(package, cancellationToken);
         }
         catch (OperationCanceledException ex)
         {
-            return Result<InstalledPluginInfo>.Failure(
+            return Result<DownloadedPluginPackage>.Failure(
                 Error.Plugin(
                     PluginErrorCodes.RemoteDownloadCanceled,
                     "插件下载已取消",
@@ -159,7 +199,7 @@ public sealed class PluginPackageService : IPluginPackageService
 
         if (sourcesResult.IsFailure)
         {
-            return Result<InstalledPluginInfo>.Failure(sourcesResult.Error!);
+            return Result<DownloadedPluginPackage>.Failure(sourcesResult.Error!);
         }
 
         var attemptErrors = new List<string>();
@@ -172,23 +212,18 @@ public sealed class PluginPackageService : IPluginPackageService
             {
                 await DownloadAsync(
                     source,
-                    remote.Package,
+                    package,
                     temporaryPath,
                     progress,
                     cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
-
-                var installResult = _pluginLibrary.InstallPluginPackage(temporaryPath);
-                if (installResult.IsSuccess)
-                {
-                    return installResult;
-                }
-
-                return installResult;
+                return Result<DownloadedPluginPackage>.Success(
+                    new DownloadedPluginPackage(temporaryPath, source.Id));
             }
             catch (OperationCanceledException ex)
             {
-                return Result<InstalledPluginInfo>.Failure(
+                TryDeleteFile(temporaryPath);
+                return Result<DownloadedPluginPackage>.Failure(
                     Error.Plugin(
                         PluginErrorCodes.RemoteDownloadCanceled,
                         "插件下载已取消",
@@ -198,20 +233,7 @@ public sealed class PluginPackageService : IPluginPackageService
             catch (Exception ex)
             {
                 attemptErrors.Add($"{source.Id}: {SimplifyError(ex)}");
-            }
-            finally
-            {
-                try
-                {
-                    if (File.Exists(temporaryPath))
-                    {
-                        File.Delete(temporaryPath);
-                    }
-                }
-                catch
-                {
-                    // 临时下载文件清理是 best effort。
-                }
+                TryDeleteFile(temporaryPath);
             }
         }
 
@@ -220,7 +242,7 @@ public sealed class PluginPackageService : IPluginPackageService
             $"插件下载失败，已尝试：{string.Join("；", attemptErrors)}",
             pluginId: pluginId);
         error.Metadata["AttemptedSources"] = sourcesResult.Value!.Select(source => source.Id).ToArray();
-        return Result<InstalledPluginInfo>.Failure(error);
+        return Result<DownloadedPluginPackage>.Failure(error);
     }
 
     private RemotePluginInfo? GetRemotePlugin(string pluginId)
@@ -333,6 +355,30 @@ public sealed class PluginPackageService : IPluginPackageService
             IOException => "临时文件读写失败",
             _ => exception.Message
         };
+    }
+
+    private static void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch
+        {
+            // 临时下载文件清理是 best effort。
+        }
+    }
+
+    private static bool IsSha256(string? value)
+    {
+        return value is { Length: 64 } &&
+               value.All(
+                   character =>
+                       character is >= '0' and <= '9' or
+                           >= 'a' and <= 'f');
     }
 
     private static string GetCurrentHostVersion()

--- a/AkashaNavigator/Services/PluginPermissionConsentService.cs
+++ b/AkashaNavigator/Services/PluginPermissionConsentService.cs
@@ -132,7 +132,9 @@ public sealed class PluginPermissionConsentService : IPluginPermissionConsentSer
                     executable = manifest.Companion?.Executable?.Replace('\\', '/'),
                     protocolVersion = manifest.Companion?.ProtocolVersion,
                     lifetime = manifest.Companion?.Lifetime,
-                    singleInstance = manifest.Companion?.SingleInstance
+                    singleInstance = manifest.Companion?.SingleInstance,
+                    shutdownTimeoutMs =
+                        manifest.Companion?.ShutdownTimeoutMs
                 }
                 : null
         };
@@ -168,9 +170,17 @@ public sealed class PluginPermissionConsentService : IPluginPermissionConsentSer
             var permissionLines = string.Join(
                 Environment.NewLine,
                 permissions.Select(permission => $"• {DescribePermission(permission)}"));
+            var companionDetails =
+                permissions.Contains(
+                    PluginPermissions.Companion,
+                    StringComparer.OrdinalIgnoreCase)
+                    ? $"{Environment.NewLine}{Environment.NewLine}" +
+                      $"将启动可执行文件：{manifest.Companion?.Executable ?? "未声明"}{Environment.NewLine}" +
+                      $"协议版本：{manifest.Companion?.ProtocolVersion}"
+                    : string.Empty;
             var message =
                 $"插件“{manifest.Name ?? manifest.Id ?? "未知插件"}”请求以下高风险权限：{Environment.NewLine}{Environment.NewLine}" +
-                $"{permissionLines}{Environment.NewLine}{Environment.NewLine}" +
+                $"{permissionLines}{companionDetails}{Environment.NewLine}{Environment.NewLine}" +
                 "仅在你信任插件来源时允许。Akasha 会限制可执行文件路径和启动参数，但该进程仍能在当前用户权限下运行。";
             var dialog = _dialogFactory.CreateConfirmDialog(
                 message,

--- a/AkashaNavigator/Services/PluginReleaseArchiveExtractor.cs
+++ b/AkashaNavigator/Services/PluginReleaseArchiveExtractor.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace AkashaNavigator.Services;
+
+/// <summary>
+/// 将已完成外层大小和哈希校验的 Release ZIP 安全解压到 staging。
+/// </summary>
+internal static class PluginReleaseArchiveExtractor
+{
+    private const int MaxPackageEntries = 20_000;
+    private const long MaxPackageEntryBytes = 256L * 1024 * 1024;
+    private const long MaxPackageUncompressedBytes = 512L * 1024 * 1024;
+
+    public static string Extract(string archivePath, string extractionRoot)
+    {
+        Directory.CreateDirectory(extractionRoot);
+        using var archive = ZipFile.OpenRead(archivePath);
+        if (archive.Entries.Count == 0)
+        {
+            throw new InvalidDataException("插件包为空");
+        }
+
+        if (archive.Entries.Count > MaxPackageEntries)
+        {
+            throw new InvalidDataException(
+                $"插件包文件数量超过限制（{MaxPackageEntries}）");
+        }
+
+        long totalLength = 0;
+        var rootPrefix = Path.GetFullPath(extractionRoot)
+            .TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar) +
+            Path.DirectorySeparatorChar;
+
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.Length > MaxPackageEntryBytes)
+            {
+                throw new InvalidDataException(
+                    $"插件包单个文件超过 256 MiB: {entry.FullName}");
+            }
+
+            totalLength = checked(totalLength + entry.Length);
+            if (totalLength > MaxPackageUncompressedBytes)
+            {
+                throw new InvalidDataException("插件包解压后大小超过 512 MiB");
+            }
+
+            var relativePath = entry.FullName.Replace('\\', '/');
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                continue;
+            }
+
+            var pathSegments = relativePath.Split(
+                '/',
+                StringSplitOptions.RemoveEmptyEntries);
+            if (relativePath.StartsWith("/", StringComparison.Ordinal) ||
+                Path.IsPathRooted(relativePath) ||
+                relativePath.Contains(':') ||
+                pathSegments.Any(segment => segment is "." or ".."))
+            {
+                throw new InvalidDataException(
+                    $"插件包包含不安全路径: {entry.FullName}");
+            }
+
+            var unixFileType = (entry.ExternalAttributes >> 16) & 0xF000;
+            var windowsAttributes = entry.ExternalAttributes & 0xFFFF;
+            if (unixFileType == 0xA000 ||
+                (windowsAttributes &
+                 (int)FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException(
+                    $"插件包不允许包含符号链接或重解析点: {entry.FullName}");
+            }
+
+            var destinationPath = Path.GetFullPath(
+                Path.Combine(
+                    extractionRoot,
+                    relativePath.Replace(
+                        '/',
+                        Path.DirectorySeparatorChar)));
+            if (!destinationPath.StartsWith(
+                    rootPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    $"插件包路径越界: {entry.FullName}");
+            }
+
+            if (relativePath.EndsWith("/", StringComparison.Ordinal))
+            {
+                Directory.CreateDirectory(destinationPath);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            using var source = entry.Open();
+            using var destination = new FileStream(
+                destinationPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None);
+            source.CopyTo(destination);
+        }
+
+        return FindPluginRoot(extractionRoot);
+    }
+
+    private static string FindPluginRoot(string extractionRoot)
+    {
+        var manifestPaths = Directory
+            .EnumerateFiles(
+                extractionRoot,
+                AppConstants.PluginRepositoryManifestFileName,
+                SearchOption.AllDirectories)
+            .ToArray();
+        if (manifestPaths.Length != 1)
+        {
+            throw new InvalidDataException(
+                manifestPaths.Length == 0
+                    ? $"插件包中没有 {AppConstants.PluginRepositoryManifestFileName}"
+                    : $"插件包中存在多个 {AppConstants.PluginRepositoryManifestFileName}");
+        }
+
+        var manifestDirectory = Path.GetDirectoryName(manifestPaths[0])!;
+        var relativeDirectory =
+            Path.GetRelativePath(extractionRoot, manifestDirectory);
+        if (relativeDirectory != "." &&
+            relativeDirectory.Split(
+                new[] {
+                    Path.DirectorySeparatorChar,
+                    Path.AltDirectorySeparatorChar
+                },
+                StringSplitOptions.RemoveEmptyEntries).Length != 1)
+        {
+            throw new InvalidDataException(
+                $"{AppConstants.PluginRepositoryManifestFileName} 只能位于 ZIP 根目录或唯一的顶层插件目录中");
+        }
+
+        if (relativeDirectory != ".")
+        {
+            var topLevelEntries =
+                Directory.EnumerateFileSystemEntries(extractionRoot).ToArray();
+            if (topLevelEntries.Length != 1 ||
+                !string.Equals(
+                    Path.GetFullPath(topLevelEntries[0]),
+                    Path.GetFullPath(manifestDirectory),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    "顶层插件目录之外包含额外文件");
+            }
+        }
+
+        return manifestDirectory;
+    }
+}

--- a/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
@@ -277,7 +277,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void UpdateAllSubscribed()
+    private async Task UpdateAllSubscribedAsync()
     {
         var updates = _pluginSubscriptionService.GetAvailableUpdates();
         if (updates.Count == 0)
@@ -293,7 +293,8 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         foreach (var update in updates)
         {
             var result =
-                _pluginInstaller.InstallOrUpdateRepositoryPlugin(update.PluginId);
+                await _pluginInstaller.InstallOrUpdateRepositoryPluginAsync(
+                    update.PluginId);
             if (result.IsSuccess)
             {
                 succeeded++;
@@ -329,9 +330,9 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         if (plugin == null)
             return;
 
-        if (plugin.IsRepositoryDistribution)
+        if (FindRepositoryEntry(plugin.Id) != null)
         {
-            InstallRepositoryPlugin(plugin);
+            await InstallCatalogPluginAsync(plugin);
             return;
         }
 
@@ -389,7 +390,7 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
     [RelayCommand]
     private void Subscribe(AvailablePluginItemModel? plugin)
     {
-        if (plugin == null || !plugin.IsRepositoryDistribution)
+        if (plugin == null)
         {
             return;
         }
@@ -638,27 +639,85 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
         };
     }
 
-    private void InstallRepositoryPlugin(AvailablePluginItemModel plugin)
+    private async Task InstallCatalogPluginAsync(
+        AvailablePluginItemModel plugin)
     {
-        var wasInstalled = plugin.IsInstalled;
-        var result = _pluginInstaller.InstallOrUpdateRepositoryPlugin(plugin.Id);
-        if (result.IsFailure)
+        if (_downloads.ContainsKey(plugin.Id))
         {
-            _notificationService.Show(
-                $"仓库插件安装失败: {result.Error?.Message}",
-                NotificationType.Error);
             return;
         }
 
-        plugin.IsInstalled = true;
-        plugin.IsSubscribed = true;
-        plugin.InstalledVersion = result.Value!.Version;
-        plugin.InstalledVersionText = $"已安装: v{result.Value.Version}";
-        plugin.HasUpdate = false;
-        _notificationService.Show(
-            $"插件 \"{plugin.Name}\" {(wasInstalled ? "更新" : "安装")}成功！",
-            NotificationType.Success);
-        RefreshRequested?.Invoke(this, EventArgs.Empty);
+        var cancellation = new CancellationTokenSource();
+        _downloads[plugin.Id] = cancellation;
+        _downloadItems[plugin.Id] = plugin;
+        var wasInstalled = plugin.IsInstalled;
+        var isRelease =
+            plugin.DistributionType == AppConstants.PluginDistributionRelease;
+        plugin.IsDownloading = isRelease;
+        plugin.DownloadProgress = 0;
+        plugin.DownloadStatus = isRelease ? "正在选择下载源…" : string.Empty;
+        var progress = new Progress<PluginDownloadProgress>(
+            value =>
+            {
+                plugin.SelectedSourceText =
+                    $"下载源：{GetSourceDisplayName(value.SourceId)}";
+                plugin.DownloadProgress =
+                    Math.Clamp(value.Percentage, 0, 100);
+                plugin.DownloadStatus =
+                    $"{FormatBytes(value.BytesReceived)} / {FormatBytes(value.TotalBytes)}";
+            });
+
+        try
+        {
+            var result =
+                await _pluginInstaller.InstallOrUpdateRepositoryPluginAsync(
+                    plugin.Id,
+                    isRelease ? progress : null,
+                    cancellation.Token);
+            if (result.IsFailure)
+            {
+                if (result.Error?.Code ==
+                    PluginErrorCodes.RemoteDownloadCanceled)
+                {
+                    _notificationService.Show(
+                        "插件下载已取消",
+                        NotificationType.Info);
+                }
+                else
+                {
+                    _notificationService.Show(
+                        $"仓库插件安装失败: {result.Error?.Message}",
+                        NotificationType.Error);
+                }
+
+                return;
+            }
+
+            plugin.IsInstalled = true;
+            plugin.IsSubscribed = true;
+            plugin.InstalledVersion = result.Value!.Version;
+            plugin.InstalledVersionText =
+                $"已安装: v{result.Value.Version}";
+            plugin.HasUpdate = false;
+            _notificationService.Show(
+                $"插件 \"{plugin.Name}\" {(wasInstalled ? "更新" : "安装")}成功！",
+                NotificationType.Success);
+            RefreshRequested?.Invoke(this, EventArgs.Empty);
+        }
+        catch (OperationCanceledException)
+        {
+            _notificationService.Show(
+                "插件下载已取消",
+                NotificationType.Info);
+        }
+        finally
+        {
+            plugin.IsDownloading = false;
+            plugin.DownloadStatus = string.Empty;
+            _downloads.Remove(plugin.Id);
+            _downloadItems.Remove(plugin.Id);
+            cancellation.Dispose();
+        }
     }
 
     private PluginRepositoryEntry? FindRepositoryEntry(string pluginId)


### PR DESCRIPTION
## What changed

- add `IPluginDistributionResolver` to prepare repository folders and Release ZIPs as validated staging inputs
- support GitHub/CNB Release mirror fallback with size and SHA-256 verification
- validate ZIP paths, symlinks/reparse points, package limits, and package manifest parity with the catalog
- make companion shutdown timeout manifest-driven, enforce protocol/backend declarations, and surface backend details in permission consent
- route plugin-center and startup installs through the unified asynchronous installer
- preserve atomic frontend/worker rollback when companion shutdown or installation fails

## Why

Phase 5 requires backend-capable plugins to install from immutable Release assets without mixing JavaScript and Worker versions, while retaining safe shutdown, rollback, and mirror behavior.

## Validation

- `dotnet test AkashaNavigator.Tests/AkashaNavigator.Tests.csproj --no-restore` — 1295 passed, 32 skipped
- `dotnet build AkashaNavigator.sln -c Release --no-restore` — 0 errors (4 existing unused-event warnings)
- `git diff --check`