### PR TITLE
refactor(plugins): complete automation repository migration

### DIFF
--- a/.github/workflows/sync_bettergi_blacklist.yml
+++ b/.github/workflows/sync_bettergi_blacklist.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sync:
-    uses: ColinXHL/akasha-automation/.github/workflows/sync_bettergi_blacklist.yml@main
+    uses: ColinXHL/akasha-plugins/.github/workflows/sync-bettergi-blacklist.yml@main
     secrets:
       QINIU_ACCESS_KEY: ${{ secrets.QINIU_ACCESS_KEY }}
       QINIU_SECRET_KEY: ${{ secrets.QINIU_SECRET_KEY }}

--- a/AkashaNavigator.Tests/Services/PluginSubscriptionServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginSubscriptionServiceTests.cs
@@ -181,6 +181,45 @@ public sealed class PluginSubscriptionServiceTests : IDisposable
     }
 
     [Fact]
+    public void Reconcile_AdoptsLegacyNoticeAutomationInstallation()
+    {
+        var installedPlugin = new InstalledPluginInfo {
+            Id = AppConstants.AutomationPluginId,
+            Name = "Akasha Genshin Automation",
+            Version = "0.4.2",
+            Source = AppConstants.PluginInstallSourceExternal
+        };
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(new List<InstalledPluginInfo> { installedPlugin });
+        var service = new PluginSubscriptionService(
+            _logService.Object,
+            GetStatePath(),
+            pluginLibrary.Object);
+        var entry = CreateEntry();
+        entry.Id = AppConstants.AutomationPluginId;
+        entry.Path = $"plugins/{AppConstants.AutomationPluginId}";
+        entry.Name = installedPlugin.Name;
+        entry.Version = "0.4.3";
+        entry.DistributionType = AppConstants.PluginDistributionRelease;
+        entry.HasBackend = true;
+        var snapshot = CreateSnapshot(entry);
+
+        var result = service.Reconcile(
+            AppConstants.OfficialPluginRepositoryId,
+            snapshot);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        var record = Assert.Single(service.GetSubscriptions());
+        Assert.Equal(AppConstants.AutomationPluginId, record.PluginId);
+        Assert.Equal(installedPlugin.Version, record.InstalledVersion);
+        Assert.Equal(snapshot.CatalogCommit, record.InstalledCommit);
+        Assert.False(record.AutoUpdate);
+        Assert.True(record.IsAvailable);
+    }
+
+    [Fact]
     public void Reconcile_DoesNotAdoptExternalOrUnknownLegacyInstallation()
     {
         var pluginLibrary = new Mock<IPluginLibrary>();

--- a/AkashaNavigator/Services/PluginSubscriptionService.cs
+++ b/AkashaNavigator/Services/PluginSubscriptionService.cs
@@ -302,7 +302,7 @@ public sealed class PluginSubscriptionService : IPluginSubscriptionService
                 {
                     _logService.Info(
                         nameof(PluginSubscriptionService),
-                        "已将旧内置插件 {PluginId} 认领为官方仓库订阅，自动更新保持关闭",
+                        "已将旧版插件 {PluginId} 认领为官方仓库订阅，自动更新保持关闭",
                         pluginId);
                 }
             }
@@ -337,7 +337,15 @@ public sealed class PluginSubscriptionService : IPluginSubscriptionService
                 string.Equals(
                     installedPlugin.Source,
                     AppConstants.PluginInstallSourceMigrated,
-                    StringComparison.OrdinalIgnoreCase);
+                    StringComparison.OrdinalIgnoreCase) ||
+                (string.Equals(
+                     installedPlugin.Id,
+                     AppConstants.AutomationPluginId,
+                     StringComparison.OrdinalIgnoreCase) &&
+                 string.Equals(
+                     installedPlugin.Source,
+                     AppConstants.PluginInstallSourceExternal,
+                     StringComparison.OrdinalIgnoreCase));
             if (!isLegacySource ||
                 Find(installedPlugin.Id) != null)
             {
@@ -349,7 +357,7 @@ public sealed class PluginSubscriptionService : IPluginSubscriptionService
             {
                 _logService.Warn(
                     nameof(PluginSubscriptionService),
-                    "旧内置插件 {PluginId} 无法在官方 catalog 中唯一识别，保留原安装且不建立订阅",
+                    "旧版插件 {PluginId} 无法在官方 catalog 中唯一识别，保留原安装且不建立订阅",
                     installedPlugin.Id);
                 continue;
             }


### PR DESCRIPTION
## Summary

- point BetterGI blacklist synchronization at the reusable workflow in AkashaPlugins
- recognize legacy notice-installed `akasha-genshin-automation` packages as the same official catalog plugin
- create the official subscription without replacing files, profiles, or configuration
- preserve the installed version/catalog commit and keep auto-update disabled until the user opts in
- continue rejecting automatic adoption of arbitrary external ZIP plugins

## Validation

- full Release test suite: 1,296 passed, 32 skipped, 0 failed (1,328 total)
- legacy notice automation adoption test passed
- BetterGI workflow YAML/target contract passed
- repository-wide scan found no independent `akasha-automation` URL, dispatch event, or dispatch token dependency

This completes the AkashaNavigator side of Phase 6. Removal of the generic legacy notice plugin model remains a separate Phase 7 change.