### PR TITLE
fix(plugins): improve plugin center updates

### DIFF
--- a/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
@@ -178,6 +178,49 @@ public sealed class PluginInstallerTests : IDisposable
     }
 
     [Fact]
+    public void InstallOrUpdateRepositoryPlugin_AllowsPreviewHostOnSameReleaseLine()
+    {
+        var entry = CreateEntry();
+        WriteCatalogPlugin(CreateManifest());
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.Subscribe(
+                AppConstants.OfficialPluginRepositoryId,
+                entry))
+            .Returns(
+                Result<PluginSubscriptionRecord>.Success(
+                    new PluginSubscriptionRecord { PluginId = PluginId }));
+        subscriptions
+            .Setup(service => service.MarkInstalled(
+                PluginId,
+                "1.0.0",
+                new string('b', 40)))
+            .Returns(Result.Success());
+        var library = new Mock<IPluginLibrary>();
+        library
+            .Setup(service => service.InstallOrUpdateFromDirectory(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>()))
+            .Returns(
+                Result<InstalledPluginInfo>.Success(
+                    new InstalledPluginInfo {
+                        Id = PluginId,
+                        Name = "Sample",
+                        Version = "1.0.0"
+                    }));
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions.Object,
+            library.Object,
+            () => "1.4.0-alpha.2");
+
+        var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+    }
+
+    [Fact]
     public void InstallOrUpdateRepositoryPlugin_EndToEndPreservesUserFile()
     {
         var entry = CreateEntry();
@@ -225,6 +268,57 @@ public sealed class PluginInstallerTests : IDisposable
         var subscription = subscriptions.GetSubscription(PluginId);
         Assert.Equal("2.0.0", subscription?.InstalledVersion);
         Assert.Equal(new string('b', 40), subscription?.InstalledCommit);
+    }
+
+    [Fact]
+    public void InstallOrUpdateRepositoryPlugin_EndToEndPreservesDirectoryMarker()
+    {
+        var entry = CreateEntry();
+        var manifest = CreateManifest();
+        manifest.SavedFiles = new List<string> { "data/" };
+        WriteCatalogPlugin(manifest);
+        var installRoot = Path.Combine(
+            _repositoryDirectory,
+            "directory-marker-install");
+        var library = new PluginLibrary(
+            Path.Combine(installRoot, "installed"),
+            Path.Combine(installRoot, "library.json"),
+            Path.Combine(installRoot, "builtin"),
+            Mock.Of<ICompanionProcessManager>(),
+            CreateConsentService());
+        var subscriptions = new PluginSubscriptionService(
+            Mock.Of<ILogService>(),
+            Path.Combine(installRoot, "plugin-subscriptions.json"));
+        var installer = new PluginInstaller(
+            CreateRepositoryService(entry).Object,
+            subscriptions,
+            library,
+            () => "1.4.0-alpha.2");
+
+        var installResult =
+            installer.InstallOrUpdateRepositoryPlugin(PluginId);
+        Assert.True(installResult.IsSuccess, installResult.Error?.Message);
+        var installedDirectory = Path.Combine(
+            installRoot,
+            "installed",
+            PluginId);
+        var userDataDirectory = Path.Combine(installedDirectory, "data");
+        Directory.CreateDirectory(userDataDirectory);
+        File.WriteAllText(
+            Path.Combine(userDataDirectory, "user.json"),
+            "user data");
+
+        entry.Version = "2.0.0";
+        manifest.Version = "2.0.0";
+        WriteCatalogPlugin(manifest);
+        var updateResult =
+            installer.InstallOrUpdateRepositoryPlugin(PluginId);
+
+        Assert.True(updateResult.IsSuccess, updateResult.Error?.Message);
+        Assert.Equal(
+            "user data",
+            File.ReadAllText(
+                Path.Combine(installedDirectory, "data", "user.json")));
     }
 
     [Fact]
@@ -287,7 +381,7 @@ public sealed class PluginInstallerTests : IDisposable
                                 directory,
                                 "runtime",
                                 "worker.exe")));
-                    Assert.Equal(new[] { "data/user.json" }, savedFiles);
+                    Assert.Equal(new[] { "data" }, savedFiles);
                 })
             .Returns(
                 Result<InstalledPluginInfo>.Success(
@@ -489,7 +583,7 @@ public sealed class PluginInstallerTests : IDisposable
         manifest.Permissions = new List<string> {
             PluginPermissions.Companion
         };
-        manifest.SavedFiles = new List<string> { "data/user.json" };
+        manifest.SavedFiles = new List<string> { "data/" };
         manifest.Distribution = CreateReleaseDistribution();
         manifest.Backend = new CatalogPluginBackend {
             Type = AppConstants.CompanionBackendType,

--- a/AkashaNavigator.Tests/Services/PluginVersionTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginVersionTests.cs
@@ -25,4 +25,28 @@ public sealed class PluginVersionTests
     {
         Assert.Equal(0, PluginLibrary.CompareVersions(left, right));
     }
+
+    [Theory]
+    [InlineData("1.4.0-alpha.2", "1.4.0")]
+    [InlineData("1.4.0-beta.1", "1.4.0")]
+    [InlineData("1.4.0", "1.4.0")]
+    [InlineData("1.4.1-alpha.1", "1.4.0")]
+    [InlineData("1.4.0-alpha.2", "1.4.0-alpha.1")]
+    public void IsHostVersionCompatible_ShouldAcceptSupportedHost(
+        string current,
+        string minimum)
+    {
+        Assert.True(PluginLibrary.IsHostVersionCompatible(current, minimum));
+    }
+
+    [Theory]
+    [InlineData("1.3.9", "1.4.0")]
+    [InlineData("1.4.0-alpha.1", "1.4.0-alpha.2")]
+    [InlineData("1.4.0-alpha.2", "1.4.1")]
+    public void IsHostVersionCompatible_ShouldRejectUnsupportedHost(
+        string current,
+        string minimum)
+    {
+        Assert.False(PluginLibrary.IsHostVersionCompatible(current, minimum));
+    }
 }

--- a/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/AvailablePluginsPageViewModelTests.cs
@@ -63,6 +63,39 @@ public sealed class AvailablePluginsPageViewModelTests
     }
 
     [Fact]
+    public void RefreshPluginList_MovesAvailableUpdatesBeforeOtherPlugins()
+    {
+        var snapshot = CreateSnapshot(usedCache: false);
+        snapshot.Index.Plugins[0].Name = "Zulu Update";
+        snapshot.Index.Plugins[1].Name = "Alpha Current";
+        var pluginLibrary = new Mock<IPluginLibrary>();
+        pluginLibrary
+            .Setup(library => library.GetInstalledPlugins())
+            .Returns(
+                new List<InstalledPluginInfo> {
+                    new() {
+                        Id = "alpha-plugin",
+                        Name = "Zulu Update",
+                        Version = "1.0.0"
+                    },
+                    new() {
+                        Id = "beta-plugin",
+                        Name = "Alpha Current",
+                        Version = "1.0.0"
+                    }
+                });
+        var viewModel = CreateViewModel(
+            CreateRepositoryService(snapshot).Object,
+            pluginLibrary.Object);
+
+        viewModel.RefreshPluginList();
+
+        Assert.Equal("alpha-plugin", viewModel.Plugins[0].Id);
+        Assert.True(viewModel.Plugins[0].HasUpdate);
+        Assert.False(viewModel.Plugins[1].HasUpdate);
+    }
+
+    [Fact]
     public async Task OnLoadedAsync_ReportsCachedRepositoryAndDoesNotRefreshLegacyManifest()
     {
         var snapshot = CreateSnapshot(usedCache: true);

--- a/AkashaNavigator.Tests/ViewModels/GeneralSettingsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/GeneralSettingsPageViewModelTests.cs
@@ -1,0 +1,73 @@
+using AkashaNavigator.Core.Events;
+using AkashaNavigator.Core.Events.Events;
+using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Models.Config;
+using AkashaNavigator.Models.Profile;
+using AkashaNavigator.ViewModels.Pages.Settings;
+using Moq;
+using Xunit;
+
+namespace AkashaNavigator.Tests.ViewModels;
+
+public sealed class GeneralSettingsPageViewModelTests
+{
+    [Fact]
+    public void ReleaseEventSubscriptions_UnsubscribesOnlyOnce()
+    {
+        var eventBus = new Mock<IEventBus>();
+        var viewModel = CreateViewModel(eventBus.Object);
+
+        viewModel.ReleaseEventSubscriptions();
+        viewModel.ReleaseEventSubscriptions();
+
+        eventBus.Verify(
+            bus => bus.Unsubscribe<OpacityChangedEvent>(
+                It.IsAny<Action<OpacityChangedEvent>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ReleaseEventSubscriptions_StopsFutureOpacityUpdates()
+    {
+        var eventBus = new EventBus();
+        var viewModel = CreateViewModel(eventBus);
+        eventBus.Publish(
+            new OpacityChangedEvent {
+                Opacity = 0.5,
+                Source = OpacityChangeSource.Hotkey
+            });
+        Assert.Equal(50, viewModel.OpacityPercent);
+
+        viewModel.ReleaseEventSubscriptions();
+        eventBus.Publish(
+            new OpacityChangedEvent {
+                Opacity = 0.75,
+                Source = OpacityChangeSource.Hotkey
+            });
+
+        Assert.Equal(50, viewModel.OpacityPercent);
+    }
+
+    private static GeneralSettingsPageViewModel CreateViewModel(
+        IEventBus eventBus)
+    {
+        var configService = new Mock<IConfigService>();
+        configService
+            .SetupGet(service => service.Config)
+            .Returns(new AppConfig());
+        var profile = new GameProfile();
+        var profileManager = new Mock<IProfileManager>();
+        profileManager
+            .SetupGet(service => service.InstalledProfiles)
+            .Returns(new[] { profile });
+        profileManager
+            .SetupGet(service => service.CurrentProfile)
+            .Returns(profile);
+
+        return new GeneralSettingsPageViewModel(
+            configService.Object,
+            profileManager.Object,
+            Mock.Of<IWindowStateService>(),
+            eventBus);
+    }
+}

--- a/AkashaNavigator.Tests/ViewModels/InstalledPluginsPageViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/InstalledPluginsPageViewModelTests.cs
@@ -45,6 +45,47 @@ public sealed class InstalledPluginsPageViewModelTests
     }
 
     [Fact]
+    public async Task OnLoadedAsync_MovesAvailableUpdatesBeforeOtherPlugins()
+    {
+        var subscriptions = new Mock<IPluginSubscriptionService>();
+        subscriptions
+            .Setup(service => service.CheckForUpdatesAsync(
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                Result<IReadOnlyList<PluginSubscriptionUpdate>>.Success(
+                    new[] {
+                        new PluginSubscriptionUpdate {
+                            PluginId = "zulu-plugin",
+                            InstalledVersion = "1.0.0",
+                            AvailableVersion = "2.0.0"
+                        }
+                    }));
+        var installed = new List<InstalledPluginInfo> {
+            new() {
+                Id = "alpha-plugin",
+                Name = "Alpha Current",
+                Version = "1.0.0"
+            },
+            new() {
+                Id = "zulu-plugin",
+                Name = "Zulu Update",
+                Version = "1.0.0"
+            }
+        };
+        var viewModel = CreateViewModel(
+            subscriptions.Object,
+            out _,
+            installed);
+
+        await viewModel.OnLoadedAsync();
+
+        Assert.Equal("zulu-plugin", viewModel.Plugins[0].Id);
+        Assert.True(viewModel.Plugins[0].HasUpdate);
+        Assert.False(viewModel.Plugins[1].HasUpdate);
+    }
+
+    [Fact]
     public async Task UpdatePluginCommand_UsesRepositoryInstaller()
     {
         var subscriptions = new Mock<IPluginSubscriptionService>();
@@ -83,12 +124,14 @@ public sealed class InstalledPluginsPageViewModelTests
 
     private static InstalledPluginsPageViewModel CreateViewModel(
         IPluginSubscriptionService subscriptions,
-        out Mock<IPluginInstaller> installer)
+        out Mock<IPluginInstaller> installer,
+        IReadOnlyList<InstalledPluginInfo>? installedPlugins = null)
     {
         var library = new Mock<IPluginLibrary>();
         library
             .Setup(service => service.GetInstalledPlugins())
             .Returns(
+                installedPlugins?.ToList() ??
                 new List<InstalledPluginInfo> {
                     new() {
                         Id = "sample-plugin",

--- a/AkashaNavigator.Tests/ViewModels/PluginCenterViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/PluginCenterViewModelTests.cs
@@ -1,0 +1,44 @@
+using AkashaNavigator.ViewModels.Windows;
+using Xunit;
+
+namespace AkashaNavigator.Tests.ViewModels;
+
+public sealed class PluginCenterViewModelTests
+{
+    [Fact]
+    public void Constructor_DoesNotResolveDuplicatePageViewModels()
+    {
+        var constructor = Assert.Single(
+            typeof(PluginCenterViewModel).GetConstructors());
+
+        Assert.Empty(constructor.GetParameters());
+    }
+
+    [Theory]
+    [InlineData(
+        nameof(PluginCenterViewModel.NavigateToMyProfilesCommand),
+        PluginCenterPageType.MyProfiles)]
+    [InlineData(
+        nameof(PluginCenterViewModel.NavigateToProfileMarketCommand),
+        PluginCenterPageType.ProfileMarket)]
+    [InlineData(
+        nameof(PluginCenterViewModel.NavigateToInstalledPluginsCommand),
+        PluginCenterPageType.InstalledPlugins)]
+    [InlineData(
+        nameof(PluginCenterViewModel.NavigateToAvailablePluginsCommand),
+        PluginCenterPageType.AvailablePlugins)]
+    public void NavigationCommand_ChangesCurrentPage(
+        string commandPropertyName,
+        PluginCenterPageType expectedPage)
+    {
+        var viewModel = new PluginCenterViewModel();
+        var commandProperty =
+            typeof(PluginCenterViewModel).GetProperty(commandPropertyName);
+        var command = Assert.IsAssignableFrom<System.Windows.Input.ICommand>(
+            commandProperty?.GetValue(viewModel));
+
+        command.Execute(null);
+
+        Assert.Equal(expectedPage, viewModel.CurrentPage);
+    }
+}

--- a/AkashaNavigator/Core/ServiceCollectionExtensions.cs
+++ b/AkashaNavigator/Core/ServiceCollectionExtensions.cs
@@ -244,9 +244,7 @@ public static class ServiceCollectionExtensions
         //         HotkeySettingsPageViewModel, AdvancedSettingsPageViewModel)
         services.AddTransient<SettingsViewModel>();
 
-        // PluginCenterViewModel（依赖 4 个 PageViewModel）
-        // 依赖链：PluginCenterViewModel → (MyProfilesPageViewModel, InstalledPluginsPageViewModel,
-        //         AvailablePluginsPageViewModel, ProfileMarketPageViewModel)
+        // PluginCenterViewModel（仅负责页面导航；实际页面刷新由 PluginCenterWindow 协调）
         services.AddTransient<PluginCenterViewModel>();
 
         // PioneerNoteViewModel（依赖 IPioneerNoteService）

--- a/AkashaNavigator/Services/PluginInstaller.cs
+++ b/AkashaNavigator/Services/PluginInstaller.cs
@@ -352,13 +352,15 @@ public sealed class PluginInstaller : IPluginInstaller
             }
         }
 
-        if (PluginLibrary.CompareVersions(
-                _hostVersionProvider(),
-                manifest.Host.MinVersion) < 0)
+        var currentHostVersion = _hostVersionProvider();
+        if (!PluginLibrary.IsHostVersionCompatible(
+                currentHostVersion,
+                manifest.Host.MinVersion))
         {
             return Error.Plugin(
                 PluginErrorCodes.HostVersionTooLow,
-                $"插件需要 AkashaNavigator {manifest.Host.MinVersion} 或更高版本",
+                $"插件需要 AkashaNavigator {manifest.Host.MinVersion} 或更高版本" +
+                $"（当前 {currentHostVersion}）",
                 pluginId: entry.Id);
         }
 
@@ -433,6 +435,9 @@ public sealed class PluginInstaller : IPluginInstaller
         }
 
         manifest.SavedFiles ??= new List<string>();
+        manifest.SavedFiles = manifest.SavedFiles
+            .Select(NormalizeSavedFilePath)
+            .ToList();
         var protectedPaths = new List<string> {
             AppConstants.PluginManifestFileName,
             AppConstants.PluginRepositoryManifestFileName,
@@ -461,6 +466,11 @@ public sealed class PluginInstaller : IPluginInstaller
         return runtimeValidation.IsValid
             ? null
             : InvalidManifest(entry.Id, "转换后的运行时清单无效");
+    }
+
+    private static string NormalizeSavedFilePath(string? relativePath)
+    {
+        return relativePath?.TrimEnd('/') ?? string.Empty;
     }
 
     private Error? ValidateReleasePackageManifest(

--- a/AkashaNavigator/Services/PluginLibrary.cs
+++ b/AkashaNavigator/Services/PluginLibrary.cs
@@ -642,6 +642,7 @@ public class PluginLibrary : IPluginLibrary
         string rootDirectory,
         string relativePath)
     {
+        relativePath = relativePath?.TrimEnd('/') ?? string.Empty;
         if (string.IsNullOrWhiteSpace(relativePath) ||
             Path.IsPathRooted(relativePath) ||
             relativePath.Contains('\\') ||
@@ -1066,6 +1067,48 @@ public class PluginLibrary : IPluginLibrary
         }
 
         return parsed1.PreRelease.Length.CompareTo(parsed2.PreRelease.Length);
+    }
+
+    /// <summary>
+    /// 判断当前宿主是否满足插件声明的最低宿主版本。
+    /// </summary>
+    /// <remarks>
+    /// 插件版本排序遵循严格 SemVer；宿主兼容性额外允许同一发布线的预发布宿主
+    /// 满足不带预发布标签的最低版本，例如 1.4.0-alpha.2 可运行要求 1.4.0
+    /// 的插件。若最低版本明确包含预发布标签，则仍按完整 SemVer 比较。
+    /// </remarks>
+    public static bool IsHostVersionCompatible(
+        string? currentVersion,
+        string? minimumVersion)
+    {
+        if (!TryParseSemanticVersion(currentVersion ?? string.Empty, out var current) ||
+            !TryParseSemanticVersion(minimumVersion ?? string.Empty, out var minimum))
+        {
+            return CompareVersions(currentVersion, minimumVersion) >= 0;
+        }
+
+        var coreComparison = CompareCoreVersions(current, minimum);
+        if (coreComparison != 0)
+        {
+            return coreComparison > 0;
+        }
+
+        return minimum.PreRelease.Length == 0 ||
+               CompareVersions(currentVersion, minimumVersion) >= 0;
+    }
+
+    private static int CompareCoreVersions(
+        SemanticPluginVersion left,
+        SemanticPluginVersion right)
+    {
+        var comparison = left.Major.CompareTo(right.Major);
+        if (comparison != 0)
+            return comparison;
+
+        comparison = left.Minor.CompareTo(right.Minor);
+        return comparison != 0
+            ? comparison
+            : left.Patch.CompareTo(right.Patch);
     }
 
     private static bool TryParseSemanticVersion(string value, out SemanticPluginVersion version)

--- a/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/AvailablePluginsPageViewModel.cs
@@ -215,7 +215,8 @@ public partial class AvailablePluginsPageViewModel : ObservableObject
                         subscription,
                         installed.GetValueOrDefault(subscription.PluginId))));
         return items
-            .OrderBy(item => item.Name, StringComparer.CurrentCultureIgnoreCase)
+            .OrderByDescending(item => item.HasUpdate)
+            .ThenBy(item => item.Name, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
     }
 

--- a/AkashaNavigator/ViewModels/Pages/InstalledPluginsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/InstalledPluginsPageViewModel.cs
@@ -176,7 +176,13 @@ public partial class InstalledPluginsPageViewModel : ObservableObject, IDisposab
         }
 
         // 转换为视图模型
-        var viewModels = plugins.Select(p => CreatePluginItemModel(p)).ToList();
+        var viewModels = plugins
+            .Select(CreatePluginItemModel)
+            .OrderByDescending(plugin => plugin.HasUpdate)
+            .ThenBy(
+                plugin => plugin.Name,
+                StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
 
         Plugins.Clear();
         foreach (var vm in viewModels)

--- a/AkashaNavigator/ViewModels/Pages/Settings/GeneralSettingsPageViewModel.cs
+++ b/AkashaNavigator/ViewModels/Pages/Settings/GeneralSettingsPageViewModel.cs
@@ -20,6 +20,7 @@ public partial class GeneralSettingsPageViewModel : ObservableObject
     private readonly IWindowStateService _windowStateService;
     private readonly IEventBus _eventBus;
     private AppConfig _config;
+    private bool _eventSubscriptionsReleased;
 
     /// <summary>
     /// 可用 Profile 列表
@@ -71,6 +72,22 @@ public partial class GeneralSettingsPageViewModel : ObservableObject
             return;
 
         OpacityPercent = (int)(e.Opacity * 100);
+    }
+
+    /// <summary>
+    /// 释放由当前设置页建立的全局事件订阅。
+    /// 此 ViewModel 由根 DI 容器按 Transient 解析，因此不实现 IDisposable，
+    /// 避免容器将实例保留到应用退出。
+    /// </summary>
+    public void ReleaseEventSubscriptions()
+    {
+        if (_eventSubscriptionsReleased)
+        {
+            return;
+        }
+
+        _eventBus.Unsubscribe<OpacityChangedEvent>(OnOpacityChanged);
+        _eventSubscriptionsReleased = true;
     }
 
     /// <summary>

--- a/AkashaNavigator/ViewModels/Windows/PluginCenterViewModel.cs
+++ b/AkashaNavigator/ViewModels/Windows/PluginCenterViewModel.cs
@@ -1,39 +1,20 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using AkashaNavigator.ViewModels.Pages;
 
 namespace AkashaNavigator.ViewModels.Windows
 {
 /// <summary>
 /// 插件中心窗口 ViewModel
-/// 遵循 MVVM 原则：ViewModel 只依赖 PageViewModel，不直接引用 View
+/// 只负责页面导航；页面刷新由持有实际 Page 实例的窗口负责。
 /// </summary>
 public partial class PluginCenterViewModel : ObservableObject
 {
-    private readonly MyProfilesPageViewModel _myProfilesPageVM;
-    private readonly ProfileMarketPageViewModel _profileMarketPageVM;
-    private readonly InstalledPluginsPageViewModel _installedPluginsPageVM;
-    private readonly AvailablePluginsPageViewModel _availablePluginsPageVM;
-
     /// <summary>
     /// 当前显示的页面类型（自动生成属性和通知）
     /// </summary>
     [ObservableProperty]
     private PluginCenterPageType _currentPage = PluginCenterPageType.MyProfiles;
-
-    public PluginCenterViewModel(MyProfilesPageViewModel myProfilesPageVM,
-                                 ProfileMarketPageViewModel profileMarketPageVM,
-                                 InstalledPluginsPageViewModel installedPluginsPageVM,
-                                 AvailablePluginsPageViewModel availablePluginsPageVM)
-    {
-        _myProfilesPageVM = myProfilesPageVM ?? throw new ArgumentNullException(nameof(myProfilesPageVM));
-        _profileMarketPageVM = profileMarketPageVM ?? throw new ArgumentNullException(nameof(profileMarketPageVM));
-        _installedPluginsPageVM =
-            installedPluginsPageVM ?? throw new ArgumentNullException(nameof(installedPluginsPageVM));
-        _availablePluginsPageVM =
-            availablePluginsPageVM ?? throw new ArgumentNullException(nameof(availablePluginsPageVM));
-    }
 
     /// <summary>
     /// 导航到我的配置页面（自动生成 NavigateToMyProfilesCommand）
@@ -69,53 +50,6 @@ public partial class PluginCenterViewModel : ObservableObject
     private void NavigateToAvailablePlugins()
     {
         CurrentPage = PluginCenterPageType.AvailablePlugins;
-    }
-
-    /// <summary>
-    /// CurrentPage 属性变化时的处理（由 CommunityToolkit.Mvvm 自动调用）
-    /// </summary>
-    partial void OnCurrentPageChanged(PluginCenterPageType value)
-    {
-        // 刷新页面数据（通过 PageViewModel 调用）
-        switch (value)
-        {
-        case PluginCenterPageType.MyProfiles:
-            _myProfilesPageVM.RefreshProfileList();
-            break;
-        case PluginCenterPageType.ProfileMarket:
-            // Fire-and-forget: 异步加载但不阻塞 UI
-            _ = _profileMarketPageVM.LoadProfilesAsync();
-            break;
-        case PluginCenterPageType.InstalledPlugins:
-            _installedPluginsPageVM.CheckAndRefreshPluginList();
-            break;
-        case PluginCenterPageType.AvailablePlugins:
-            _availablePluginsPageVM.RefreshPluginList();
-            break;
-        }
-    }
-
-    /// <summary>
-    /// 刷新当前页面
-    /// </summary>
-    public void RefreshCurrentPage()
-    {
-        switch (CurrentPage)
-        {
-        case PluginCenterPageType.MyProfiles:
-            _myProfilesPageVM.RefreshProfileList();
-            break;
-        case PluginCenterPageType.ProfileMarket:
-            // Fire-and-forget: 异步加载但不阻塞 UI
-            _ = _profileMarketPageVM.LoadProfilesAsync();
-            break;
-        case PluginCenterPageType.InstalledPlugins:
-            _installedPluginsPageVM.CheckAndRefreshPluginList();
-            break;
-        case PluginCenterPageType.AvailablePlugins:
-            _availablePluginsPageVM.RefreshPluginList();
-            break;
-        }
     }
 }
 

--- a/AkashaNavigator/ViewModels/Windows/SettingsViewModel.cs
+++ b/AkashaNavigator/ViewModels/Windows/SettingsViewModel.cs
@@ -395,6 +395,14 @@ public partial class SettingsViewModel : ObservableObject
     {
         _generalPageVM.RefreshSettings();
     }
+
+    /// <summary>
+    /// 释放设置页建立的全局事件订阅。
+    /// </summary>
+    public void ReleaseEventSubscriptions()
+    {
+        _generalPageVM.ReleaseEventSubscriptions();
+    }
 }
 
 /// <summary>

--- a/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
+++ b/AkashaNavigator/Views/Pages/AvailablePluginsPage.xaml
@@ -1,15 +1,9 @@
 <UserControl x:Class="AkashaNavigator.Views.Pages.AvailablePluginsPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="clr-namespace:AkashaNavigator.ViewModels.Pages"
              xmlns:repository="clr-namespace:AkashaNavigator.Models.PluginRepository"
              Background="Transparent"
              Cursor="Arrow">
-
-    <!-- 已移除本地资源定义，使用全局样式：
-         - BoolToVisibilityConverter -> 全局 Converters.xaml
-         - InverseBoolToVisibilityConverter -> 全局 Converters.xaml
-         - LocalPrimaryButtonStyle -> 全局 PrimaryActionButtonStyle -->
 
     <Grid>
         <Grid.RowDefinitions>
@@ -19,77 +13,204 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- 标题和搜索栏 -->
+        <!-- 页面标题与全局工具 -->
         <Grid Grid.Row="0" Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Text="可用插件" FontSize="18" FontWeight="SemiBold"
-                       Foreground="White" VerticalAlignment="Center"/>
-            <Button Grid.Column="1" Content="📦 从 ZIP 安装"
+
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="可用插件"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimaryBrush}"/>
+                <TextBlock Text="发现、订阅并安装官方 catalog 中的插件"
+                           Margin="0,4,0,0"
+                           FontSize="11"
+                           Foreground="{StaticResource TextSecondaryBrush}"/>
+            </StackPanel>
+
+            <Button Grid.Column="1"
+                    Content="从 ZIP 安装"
                     Style="{StaticResource ActionButtonStyle}"
                     Margin="0,0,12,0"
+                    VerticalAlignment="Center"
                     Click="OnInstallPackageClick"/>
-            <TextBox x:Name="SearchBox" Grid.Column="2" Width="200"
-                     Style="{StaticResource SearchBoxStyle}" Tag="搜索插件..."
+
+            <TextBox x:Name="SearchBox"
+                     Grid.Column="2"
+                     Width="240"
+                     Style="{StaticResource SearchBoxStyle}"
+                     Tag="搜索插件..."
+                     VerticalAlignment="Center"
                      Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
 
         <!-- 仓库设置 -->
-        <WrapPanel Grid.Row="1" Margin="0,0,0,12" VerticalAlignment="Center">
-            <ComboBox Width="105" Margin="0,0,8,0"
-                      SelectedValuePath="Tag"
-                      SelectedValue="{Binding SelectedRepositoryChannel}">
-                <ComboBoxItem Content="GitHub"
-                              Tag="{x:Static repository:PluginRepositoryChannel.GitHub}"/>
-                <ComboBoxItem Content="CNB"
-                              Tag="{x:Static repository:PluginRepositoryChannel.Cnb}"/>
-                <ComboBoxItem Content="自定义"
-                              Tag="{x:Static repository:PluginRepositoryChannel.Custom}"/>
-            </ComboBox>
-            <TextBox Width="250" Margin="0,0,8,0"
-                     Text="{Binding CustomRepositoryUrl, UpdateSourceTrigger=PropertyChanged}"
-                     ToolTip="自定义仓库 HTTPS Git 地址"
-                     Visibility="{Binding IsCustomRepositoryChannel, Converter={StaticResource BoolToVisibilityConverter}}"/>
-            <CheckBox Content="启动时更新仓库" Margin="0,0,12,0"
-                      Foreground="#CCC" VerticalAlignment="Center"
-                      IsChecked="{Binding AutoUpdateRepository}"/>
-            <CheckBox Content="自动更新已订阅插件" Margin="0,0,12,0"
-                      Foreground="#CCC" VerticalAlignment="Center"
-                      IsChecked="{Binding AutoUpdateSubscribedPlugins}"/>
-            <Button Content="保存" Style="{StaticResource ActionButtonStyle}"
-                    Margin="0,0,8,0"
-                    Command="{Binding SaveRepositorySettingsCommand}"/>
-            <Button Content="更新仓库" Style="{StaticResource PrimaryActionButtonStyle}"
-                    Margin="0,0,8,0"
-                    Command="{Binding UpdateRepositoryCommand}"/>
-            <Button Content="重置仓库" Style="{StaticResource ActionButtonStyle}"
-                    Margin="0,0,8,0"
-                    Command="{Binding ResetRepositoryCommand}"/>
-            <Button Content="一键更新订阅" Style="{StaticResource ActionButtonStyle}"
-                    Command="{Binding UpdateAllSubscribedCommand}"/>
-        </WrapPanel>
+        <Border Grid.Row="1"
+                Margin="0,0,0,14"
+                Padding="16,14"
+                Background="{StaticResource SurfaceDarkerBrush}"
+                BorderBrush="{StaticResource BorderDarkBrush}"
+                BorderThickness="1"
+                CornerRadius="6">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
-        <!-- 统计信息 -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,16">
-            <TextBlock x:Name="PluginCountText" Text="{Binding PluginCountText}" Foreground="#888" FontSize="12"/>
-            <TextBlock Text="{Binding RepositoryStatusText}" Foreground="#60A5FA"
-                       FontSize="12" Margin="16,0,0,0"/>
-        </StackPanel>
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                        <TextBlock Text="插件仓库"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                   VerticalAlignment="Center"/>
+                        <Border Margin="10,0,0,0"
+                                Padding="7,2"
+                                Background="{StaticResource InfoBackgroundBrush}"
+                                CornerRadius="3">
+                            <TextBlock Text="catalog"
+                                       FontSize="10"
+                                       Foreground="{StaticResource InfoLightBrush}"/>
+                        </Border>
+                    </StackPanel>
+
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding RepositoryStatusText}"
+                               FontSize="11"
+                               Foreground="{StaticResource InfoLightBrush}"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <Grid Grid.Row="1" Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="124"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="仓库源"
+                               Margin="0,0,10,0"
+                               FontSize="12"
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               VerticalAlignment="Center"/>
+
+                    <ComboBox Grid.Column="1"
+                              Style="{StaticResource DarkComboBoxStyle}"
+                              ItemContainerStyle="{StaticResource DarkComboBoxItemStyle}"
+                              SelectedValuePath="Tag"
+                              SelectedValue="{Binding SelectedRepositoryChannel}">
+                        <ComboBoxItem Content="GitHub"
+                                      Tag="{x:Static repository:PluginRepositoryChannel.GitHub}"/>
+                        <ComboBoxItem Content="CNB"
+                                      Tag="{x:Static repository:PluginRepositoryChannel.Cnb}"/>
+                        <ComboBoxItem Content="自定义"
+                                      Tag="{x:Static repository:PluginRepositoryChannel.Custom}"/>
+                    </ComboBox>
+
+                    <TextBox Grid.Column="2"
+                             Margin="12,0,12,0"
+                             Style="{StaticResource DarkTextBoxStyle}"
+                             Text="{Binding CustomRepositoryUrl, UpdateSourceTrigger=PropertyChanged}"
+                             ToolTip="自定义仓库 HTTPS Git 地址"
+                             Visibility="{Binding IsCustomRepositoryChannel, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                    <StackPanel Grid.Column="3"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center">
+                        <Button Content="保存设置"
+                                Style="{StaticResource ActionButtonStyle}"
+                                Command="{Binding SaveRepositorySettingsCommand}"/>
+                        <Button Content="更新仓库"
+                                Style="{StaticResource PrimaryActionButtonStyle}"
+                                Margin="8,0,0,0"
+                                Command="{Binding UpdateRepositoryCommand}"/>
+                        <Button Content="重置"
+                                Style="{StaticResource ActionButtonStyle}"
+                                Margin="8,0,0,0"
+                                Command="{Binding ResetRepositoryCommand}"/>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Grid.Row="2" Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0"
+                              Content="启动时更新仓库"
+                              Style="{StaticResource DarkCheckBoxStyle}"
+                              FontSize="12"
+                              Foreground="{StaticResource TextMutedBrush}"
+                              IsChecked="{Binding AutoUpdateRepository}"
+                              ToolTip="仅刷新 catalog，不会替换本地插件"/>
+
+                    <CheckBox Grid.Column="1"
+                              Content="自动更新已订阅插件"
+                              Style="{StaticResource DarkCheckBoxStyle}"
+                              Margin="24,0,0,0"
+                              FontSize="12"
+                              Foreground="{StaticResource TextMutedBrush}"
+                              IsChecked="{Binding AutoUpdateSubscribedPlugins}"
+                              ToolTip="仓库刷新后自动安装允许自动更新的订阅插件"/>
+
+                    <TextBlock Grid.Column="2"
+                               Text="仓库刷新与插件安装相互独立"
+                               HorizontalAlignment="Right"
+                               VerticalAlignment="Center"
+                               FontSize="11"
+                               Foreground="{StaticResource TextDisabledBrush}"/>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- 列表摘要 -->
+        <Grid Grid.Row="2" Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock x:Name="PluginCountText"
+                       Grid.Column="0"
+                       Text="{Binding PluginCountText}"
+                       Foreground="{StaticResource TextSecondaryBrush}"
+                       FontSize="12"
+                       VerticalAlignment="Center"/>
+
+            <Button Grid.Column="1"
+                    Content="更新全部订阅"
+                    Style="{StaticResource ActionButtonStyle}"
+                    Command="{Binding UpdateAllSubscribedCommand}"/>
+        </Grid>
 
         <!-- 插件列表 -->
-        <ScrollViewer Grid.Row="3" Style="{StaticResource DarkScrollViewer}"
+        <ScrollViewer Grid.Row="3"
+                      Style="{StaticResource DarkScrollViewer}"
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <!-- 无插件提示 -->
-                <TextBlock x:Name="NoPluginsText" Text="没有可用的插件"
-                           Foreground="#666" FontSize="13" Margin="0,20,0,0"
+                <TextBlock x:Name="NoPluginsText"
+                           Text="没有可用的插件"
+                           Foreground="{StaticResource TextDisabledBrush}"
+                           FontSize="13"
+                           Margin="0,32,0,0"
                            HorizontalAlignment="Center"
                            Visibility="{Binding IsEmpty, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                <!-- 插件列表 -->
                 <ItemsControl x:Name="PluginList" ItemsSource="{Binding Plugins}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
@@ -101,7 +222,7 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
-                                    <!-- 第一行：名称、版本、状态标签 -->
+                                    <!-- 名称、版本和状态 -->
                                     <Grid Grid.Row="0">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*"/>
@@ -109,93 +230,156 @@
                                         </Grid.ColumnDefinitions>
 
                                         <StackPanel Grid.Column="0" Orientation="Horizontal">
-                                            <TextBlock Text="🔍" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                            <TextBlock Text="{Binding Name}" Foreground="White"
-                                                       FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                            <TextBlock Text="{Binding Version, StringFormat=' v{0}'}"
-                                                       Foreground="#888" FontSize="12"
-                                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                            <Border Width="28"
+                                                    Height="28"
+                                                    Margin="0,0,10,0"
+                                                    Background="{StaticResource InfoBackgroundBrush}"
+                                                    CornerRadius="6">
+                                                <TextBlock Text="◆"
+                                                           Foreground="{StaticResource InfoLightBrush}"
+                                                           FontSize="11"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center"/>
+                                            </Border>
+                                            <TextBlock Text="{Binding Name}"
+                                                       Foreground="{StaticResource TextPrimaryBrush}"
+                                                       FontSize="15"
+                                                       FontWeight="SemiBold"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Text="{Binding Version, StringFormat='v{0}'}"
+                                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                                       FontSize="11"
+                                                       VerticalAlignment="Center"
+                                                       Margin="10,0,0,0"/>
                                         </StackPanel>
 
-                                        <!-- 可安装标签：未安装时显示 -->
-                                        <Border Grid.Column="1" Style="{StaticResource AvailableTagStyle}"
+                                        <Border Grid.Column="1"
+                                                Style="{StaticResource AvailableTagStyle}"
                                                 Visibility="{Binding AvailableTagVisibility}">
-                                            <TextBlock Text="可安装" Foreground="#60A5FA" FontSize="11"/>
+                                            <TextBlock Text="可安装"
+                                                       Foreground="{StaticResource InfoLightBrush}"
+                                                       FontSize="11"/>
                                         </Border>
-                                        <!-- 已安装标签：已安装时显示 -->
-                                        <Border Grid.Column="1" Style="{StaticResource InstalledTagStyle}"
+                                        <Border Grid.Column="1"
+                                                Style="{StaticResource InstalledTagStyle}"
                                                 Visibility="{Binding InstalledTagVisibility}">
-                                            <TextBlock Text="已安装" Foreground="#4ADE80" FontSize="11"/>
+                                            <TextBlock Text="已安装"
+                                                       Foreground="{StaticResource SuccessBrush}"
+                                                       FontSize="11"/>
                                         </Border>
-                                        <Border Grid.Column="1" Style="{StaticResource AvailableTagStyle}"
+                                        <Border Grid.Column="1"
+                                                Style="{StaticResource UpdateAvailableTagStyle}"
                                                 Visibility="{Binding UpdateTagVisibility}">
-                                            <TextBlock Text="可更新" Foreground="#FBBF24" FontSize="11"/>
+                                            <TextBlock Text="可更新"
+                                                       Foreground="{StaticResource WarningTextBrush}"
+                                                       FontSize="11"/>
                                         </Border>
-                                        <Border Grid.Column="1" Style="{StaticResource AvailableTagStyle}"
+                                        <Border Grid.Column="1"
+                                                Style="{StaticResource MissingTagStyle}"
+                                                Padding="8,3"
+                                                CornerRadius="3"
                                                 Visibility="{Binding RemovedTagVisibility}">
-                                            <TextBlock Text="仓库中已移除" Foreground="#F87171" FontSize="11"/>
+                                            <TextBlock Text="仓库中已移除"
+                                                       Foreground="#F87171"
+                                                       FontSize="11"/>
                                         </Border>
                                     </Grid>
 
-                                    <!-- 第二行：描述和作者 -->
-                                    <StackPanel Grid.Row="1" Margin="0,8,0,0">
-                                        <TextBlock Text="{Binding Description}" Foreground="#AAA" FontSize="12"
-                                                   TextWrapping="Wrap" Visibility="{Binding HasDescriptionVisibility}"/>
-                                        <TextBlock Text="{Binding Author, StringFormat='作者: {0}'}"
-                                                   Foreground="#666" FontSize="11" Margin="0,4,0,0"
-                                                   Visibility="{Binding HasAuthorVisibility}"/>
-                                        <TextBlock Text="已订阅仓库更新"
-                                                   Foreground="#A78BFA" FontSize="11" Margin="0,4,0,0"
-                                                   Visibility="{Binding SubscriptionStatusVisibility}"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,5,0,0"
-                                                    Visibility="{Binding RemoteInfoVisibility}">
-                                            <TextBlock Text="{Binding PackageSizeText, StringFormat='包大小: {0}'}"
-                                                       Foreground="#777" FontSize="11"/>
-                                            <TextBlock Text="{Binding InstalledVersionText}"
-                                                       Foreground="#777" FontSize="11" Margin="14,0,0,0"/>
-                                            <TextBlock Text="{Binding SelectedSourceText}"
-                                                       Foreground="#60A5FA" FontSize="11" Margin="14,0,0,0"/>
-                                        </StackPanel>
-                                    </StackPanel>
+                                    <!-- 插件信息与操作 -->
+                                    <Grid Grid.Row="1" Margin="38,8,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-                                    <!-- 第三行：操作按钮 -->
-                                    <StackPanel Grid.Row="2" Margin="0,12,0,0">
-                                        <StackPanel Visibility="{Binding DownloadVisibility}">
-                                            <ProgressBar Height="5" Minimum="0" Maximum="100"
-                                                         Value="{Binding DownloadProgress}"
-                                                         Foreground="#3B82F6" Background="#252A34"/>
-                                            <TextBlock Text="{Binding DownloadStatus}" Foreground="#888"
-                                                       FontSize="11" Margin="0,5,0,0"/>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Description}"
+                                                       Foreground="{StaticResource TextTertiaryBrush}"
+                                                       FontSize="12"
+                                                       TextWrapping="Wrap"
+                                                       Visibility="{Binding HasDescriptionVisibility}"/>
+                                            <WrapPanel Margin="0,5,0,0">
+                                                <TextBlock Text="{Binding Author, StringFormat='作者：{0}'}"
+                                                           Foreground="{StaticResource TextDisabledBrush}"
+                                                           FontSize="11"
+                                                           Visibility="{Binding HasAuthorVisibility}"/>
+                                                <TextBlock Text="已订阅仓库更新"
+                                                           Foreground="#A78BFA"
+                                                           FontSize="11"
+                                                           Margin="14,0,0,0"
+                                                           Visibility="{Binding SubscriptionStatusVisibility}"/>
+                                            </WrapPanel>
+                                            <WrapPanel Margin="0,5,0,0"
+                                                       Visibility="{Binding RemoteInfoVisibility}">
+                                                <TextBlock Text="{Binding PackageSizeText, StringFormat='包大小：{0}'}"
+                                                           Foreground="{StaticResource TextDisabledBrush}"
+                                                           FontSize="11"/>
+                                                <TextBlock Text="{Binding InstalledVersionText}"
+                                                           Foreground="{StaticResource TextDisabledBrush}"
+                                                           FontSize="11"
+                                                           Margin="14,0,0,0"/>
+                                                <TextBlock Text="{Binding SelectedSourceText}"
+                                                           Foreground="{StaticResource InfoLightBrush}"
+                                                           FontSize="11"
+                                                           Margin="14,0,0,0"/>
+                                            </WrapPanel>
                                         </StackPanel>
-                                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                            <Button Content="📥 安装" Style="{StaticResource PrimaryActionButtonStyle}"
+
+                                        <StackPanel Grid.Column="1"
+                                                    Orientation="Horizontal"
+                                                    Margin="24,0,0,0"
+                                                    VerticalAlignment="Bottom">
+                                            <Button Content="安装"
+                                                    Style="{StaticResource PrimaryActionButtonStyle}"
                                                     Command="{Binding DataContext.InstallCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding InstallButtonVisibility}"/>
-                                            <Button Content="⬆ 更新" Style="{StaticResource PrimaryActionButtonStyle}"
+                                            <Button Content="更新"
+                                                    Style="{StaticResource PrimaryActionButtonStyle}"
                                                     Command="{Binding DataContext.InstallCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding UpdateButtonVisibility}"/>
-                                            <Button Content="取消下载" Style="{StaticResource ActionButtonStyle}"
+                                            <Button Content="取消下载"
+                                                    Style="{StaticResource ActionButtonStyle}"
+                                                    Margin="8,0,0,0"
                                                     Command="{Binding DataContext.CancelDownloadCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding CancelButtonVisibility}"/>
-                                            <Button Content="订阅" Style="{StaticResource ActionButtonStyle}"
+                                            <Button Content="订阅"
+                                                    Style="{StaticResource ActionButtonStyle}"
                                                     Margin="8,0,0,0"
                                                     Command="{Binding DataContext.SubscribeCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding SubscribeButtonVisibility}"/>
-                                            <Button Content="取消订阅" Style="{StaticResource ActionButtonStyle}"
+                                            <Button Content="取消订阅"
+                                                    Style="{StaticResource ActionButtonStyle}"
                                                     Margin="8,0,0,0"
                                                     Command="{Binding DataContext.UnsubscribeCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding UnsubscribeButtonVisibility}"/>
-                                            <Button Content="卸载" Style="{StaticResource ActionButtonStyle}"
+                                            <Button Content="卸载"
+                                                    Style="{StaticResource DangerActionButtonStyle}"
                                                     Margin="8,0,0,0"
                                                     Command="{Binding DataContext.UninstallCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                     CommandParameter="{Binding}"
                                                     Visibility="{Binding UninstallButtonVisibility}"/>
                                         </StackPanel>
+                                    </Grid>
+
+                                    <!-- 下载进度 -->
+                                    <StackPanel Grid.Row="2"
+                                                Margin="38,12,0,0"
+                                                Visibility="{Binding DownloadVisibility}">
+                                        <ProgressBar Height="5"
+                                                     Minimum="0"
+                                                     Maximum="100"
+                                                     Value="{Binding DownloadProgress}"
+                                                     Foreground="{StaticResource InfoBrush}"
+                                                     Background="{StaticResource SurfaceDarkerBrush}"/>
+                                        <TextBlock Text="{Binding DownloadStatus}"
+                                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="11"
+                                                   Margin="0,5,0,0"/>
                                     </StackPanel>
                                 </Grid>
                             </Border>

--- a/AkashaNavigator/Views/Pages/ProfileMarketPage.xaml.cs
+++ b/AkashaNavigator/Views/Pages/ProfileMarketPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Models.Plugin;
@@ -45,6 +46,14 @@ public partial class ProfileMarketPage : System.Windows.Controls.UserControl, ID
     {
         // 首次加载时获取数据
         _ = _viewModel.LoadProfilesAsync();
+    }
+
+    /// <summary>
+    /// 重新加载市场数据（公共方法供插件中心页面切换时调用）。
+    /// </summary>
+    public Task RefreshProfilesAsync()
+    {
+        return _viewModel.LoadProfilesAsync();
     }
 
     /// <summary>

--- a/AkashaNavigator/Views/Windows/PluginCenterWindow.xaml.cs
+++ b/AkashaNavigator/Views/Windows/PluginCenterWindow.xaml.cs
@@ -70,6 +70,31 @@ public partial class PluginCenterWindow : AnimatedWindow
             currentPage == PluginCenterPageType.InstalledPlugins ? Visibility.Visible : Visibility.Collapsed;
         _availablePluginsPage.Visibility =
             currentPage == PluginCenterPageType.AvailablePlugins ? Visibility.Visible : Visibility.Collapsed;
+
+        RefreshPage(currentPage);
+    }
+
+    /// <summary>
+    /// 刷新窗口中实际显示的 Page 实例。
+    /// PageViewModel 为 Transient，不能通过窗口 ViewModel 另行解析后刷新。
+    /// </summary>
+    private void RefreshPage(PluginCenterPageType page)
+    {
+        switch (page)
+        {
+        case PluginCenterPageType.MyProfiles:
+            _myProfilesPage.RefreshProfileList();
+            break;
+        case PluginCenterPageType.ProfileMarket:
+            _ = _profileMarketPage.RefreshProfilesAsync();
+            break;
+        case PluginCenterPageType.InstalledPlugins:
+            _installedPluginsPage.CheckAndRefreshPluginList();
+            break;
+        case PluginCenterPageType.AvailablePlugins:
+            _availablePluginsPage.RefreshPluginList();
+            break;
+        }
     }
 
     /// <summary>
@@ -116,7 +141,7 @@ public partial class PluginCenterWindow : AnimatedWindow
     /// </summary>
     public void RefreshCurrentPage()
     {
-        _viewModel.RefreshCurrentPage();
+        RefreshPage(_viewModel.CurrentPage);
     }
 
     private void DisposePages()

--- a/AkashaNavigator/Views/Windows/SettingsWindow.xaml.cs
+++ b/AkashaNavigator/Views/Windows/SettingsWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
@@ -47,13 +48,7 @@ public partial class SettingsWindow : AnimatedWindow
         UpdatePageVisibility(_viewModel.CurrentPage);
 
         // 订阅 ViewModel 的 PropertyChanged 事件，处理页面显示切换
-        _viewModel.PropertyChanged += (s, e) =>
-        {
-            if (e.PropertyName == nameof(_viewModel.CurrentPage))
-            {
-                UpdatePageVisibility(_viewModel.CurrentPage);
-            }
-        };
+        _viewModel.PropertyChanged += ViewModel_PropertyChanged;
 
         // 订阅搜索结果变化
         _viewModel.SearchResults.CollectionChanged += SearchResults_CollectionChanged;
@@ -63,6 +58,16 @@ public partial class SettingsWindow : AnimatedWindow
 
         // 加载 Profile 列表（通过 GeneralPage）
         _viewModel.RefreshProfileList();
+    }
+
+    private void ViewModel_PropertyChanged(
+        object? sender,
+        PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(_viewModel.CurrentPage))
+        {
+            UpdatePageVisibility(_viewModel.CurrentPage);
+        }
     }
 
     /// <summary>
@@ -180,6 +185,16 @@ public partial class SettingsWindow : AnimatedWindow
     {
         _viewModel.SaveCommand.Execute(null);
         CloseWithAnimation();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _viewModel.OpenConfigFolderRequested -= OnOpenConfigFolder;
+        _viewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        _viewModel.SearchResults.CollectionChanged -=
+            SearchResults_CollectionChanged;
+        _viewModel.ReleaseEventSubscriptions();
+        base.OnClosed(e);
     }
 }
 }


### PR DESCRIPTION
## What changed

- Reworked the available-plugins page to match the plugin center visual system.
- Moved plugins with available updates to the top of both plugin lists.
- Fixed host compatibility checks for preview builds on the same release line.
- Normalized `savedFiles` directory markers so repository updates no longer reject valid plugin packages.
- Refreshed the actual visible plugin-center pages during navigation instead of duplicate transient ViewModels.
- Released settings-window event subscriptions when the window closes.

## Why

The plugin center had inconsistent layout and update state between its two plugin views. Update installation could also fail because preview host versions were treated as older than their stable release line, or because directory entries in `savedFiles` were interpreted as plugin-code paths. The state mismatch was caused by the navigation ViewModel and the rendered pages resolving separate transient PageViewModel instances.

## User impact

Plugin update availability is now consistent when switching pages, updateable plugins are easier to find, and repository plugin updates work with preview host builds and directory-style saved-file declarations.

## Validation

- `dotnet build -c Release`
- `dotnet test -c Release --no-build`
  - 1311 passed
  - 32 skipped
  - 0 failed
