### PR TITLE
test(plugins): derive preview host version

### DIFF
--- a/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
+++ b/AkashaNavigator.Tests/Services/PluginInstallerTests.cs
@@ -181,7 +181,10 @@ public sealed class PluginInstallerTests : IDisposable
     public void InstallOrUpdateRepositoryPlugin_AllowsPreviewHostOnSameReleaseLine()
     {
         var entry = CreateEntry();
-        WriteCatalogPlugin(CreateManifest());
+        var manifest = CreateManifest();
+        WriteCatalogPlugin(manifest);
+        var previewHostVersion =
+            $"{manifest.Host.MinVersion}-alpha.2";
         var subscriptions = new Mock<IPluginSubscriptionService>();
         subscriptions
             .Setup(service => service.Subscribe(
@@ -213,7 +216,7 @@ public sealed class PluginInstallerTests : IDisposable
             CreateRepositoryService(entry).Object,
             subscriptions.Object,
             library.Object,
-            () => "1.4.0-alpha.2");
+            () => previewHostVersion);
 
         var result = installer.InstallOrUpdateRepositoryPlugin(PluginId);
 
@@ -293,7 +296,7 @@ public sealed class PluginInstallerTests : IDisposable
             CreateRepositoryService(entry).Object,
             subscriptions,
             library,
-            () => "1.4.0-alpha.2");
+            () => manifest.Host.MinVersion);
 
         var installResult =
             installer.InstallOrUpdateRepositoryPlugin(PluginId);


### PR DESCRIPTION
## What changed

- Derive the preview host test version from the catalog manifest minimum version.
- Use the manifest minimum version directly in the saved-directory integration test.

## Why

PR #32 correctly injects deterministic host versions in unit tests, but the new tests used the application's current `1.4.0-alpha.2` version as a literal. That made test data look like a production version dependency and coupled unrelated saved-file coverage to a preview release.

Production behavior is unchanged: `PluginInstaller` continues to read the host version from the entry assembly.

## Validation

- `dotnet test -c Release --filter "FullyQualifiedName~PluginInstallerTests|FullyQualifiedName~PluginVersionTests"`
  - 25 passed
  - 0 failed
