### PR TITLE
fix(plugins): restore settings UI paths

### DIFF
--- a/AkashaNavigator.Tests/Helpers/PluginSettingsPathResolverTests.cs
+++ b/AkashaNavigator.Tests/Helpers/PluginSettingsPathResolverTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text.Json;
 using AkashaNavigator.Helpers;
 using Xunit;
 
@@ -39,5 +40,69 @@ public class PluginSettingsPathResolverTests
         var result = PluginSettingsPathResolver.ResolveDirectory(root, null);
 
         Assert.Equal(Path.GetFullPath(root), result);
+    }
+
+    [Fact]
+    public void ResolveSettingsFile_WithManifestPath_UsesDeclaredLocation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "plugin-root");
+
+        var result = PluginSettingsPathResolver.ResolveSettingsFile(
+            root, "frontend/settings_ui.json");
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(root, "frontend/settings_ui.json")),
+            result);
+    }
+
+    [Fact]
+    public void ResolveSettingsFile_WithoutManifestPath_UsesLegacyLocation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "plugin-root");
+
+        var result = PluginSettingsPathResolver.ResolveSettingsFile(root, null);
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(root, AppConstants.PluginSettingsUiFileName)),
+            result);
+    }
+
+    [Fact]
+    public void ResolveSettingsFile_WithInstalledRepositoryManifest_UsesCatalogLocation()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "AkashaNavigator",
+            Path.GetRandomFileName());
+        Directory.CreateDirectory(root);
+        File.WriteAllText(
+            Path.Combine(root, AppConstants.PluginRepositoryManifestFileName),
+            JsonSerializer.Serialize(new {
+                settings = "frontend/settings_ui.json"
+            }));
+
+        try
+        {
+            var result = PluginSettingsPathResolver.ResolveSettingsFile(root, null);
+
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(root, "frontend/settings_ui.json")),
+                result);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSettingsFile_WithTraversal_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "plugin-root");
+
+        var result = PluginSettingsPathResolver.ResolveSettingsFile(
+            root, "../settings_ui.json");
+
+        Assert.Null(result);
     }
 }

--- a/AkashaNavigator.Tests/PluginManifestTests.cs
+++ b/AkashaNavigator.Tests/PluginManifestTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using AkashaNavigator.Models.Plugin;
+using AkashaNavigator.Models.PluginRepository;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
@@ -254,6 +255,41 @@ public class PluginManifestTests
         Assert.Equal("dark", result.Manifest.DefaultConfig["theme"].GetString());
         Assert.Equal(14, result.Manifest.DefaultConfig["fontSize"].GetInt32());
         Assert.True(result.Manifest.DefaultConfig["enabled"].GetBoolean());
+    }
+
+    [Fact]
+    public void Settings_ShouldDeserializeCorrectly()
+    {
+        var json = """
+                   {
+                     "id": "test-plugin",
+                     "name": "Test Plugin",
+                     "version": "1.0.0",
+                     "main": "frontend/main.js",
+                     "settings": "frontend/settings_ui.json"
+                   }
+                   """;
+
+        var result = PluginManifest.LoadFromJson(json);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("frontend/settings_ui.json", result.Manifest!.Settings);
+    }
+
+    [Fact]
+    public void CatalogManifest_ShouldPreserveSettingsInRuntimeManifest()
+    {
+        var catalogManifest = new CatalogPluginManifest {
+            Id = "test-plugin",
+            Name = "Test Plugin",
+            Version = "1.0.0",
+            Main = "frontend/main.js",
+            Settings = "frontend/settings_ui.json"
+        };
+
+        var runtimeManifest = catalogManifest.ToRuntimeManifest();
+
+        Assert.Equal("frontend/settings_ui.json", runtimeManifest.Settings);
     }
 
     /// <summary>

--- a/AkashaNavigator.Tests/ViewModels/PluginSettingsViewModelTests.cs
+++ b/AkashaNavigator.Tests/ViewModels/PluginSettingsViewModelTests.cs
@@ -31,4 +31,71 @@ public class PluginSettingsViewModelTests
 
         Assert.Equal("plugin.alpha", pluginHost.ReloadedPluginId);
     }
+
+    [Fact]
+    public void Constructor_LoadsSettingsFromManifestDeclaredPath()
+    {
+        var pluginDirectory = Path.Combine(
+            Path.GetTempPath(), "AkashaNavigator", Guid.NewGuid().ToString("N"));
+        var settingsDirectory = Path.Combine(pluginDirectory, "frontend");
+        var configDirectory = Path.Combine(pluginDirectory, "config");
+        Directory.CreateDirectory(settingsDirectory);
+        File.WriteAllText(
+            Path.Combine(pluginDirectory, AppConstants.PluginManifestFileName),
+            """
+            {
+              "id": "plugin.alpha",
+              "name": "Alpha",
+              "version": "1.0.0",
+              "main": "frontend/main.js"
+            }
+            """);
+        File.WriteAllText(
+            Path.Combine(pluginDirectory, AppConstants.PluginRepositoryManifestFileName),
+            """
+            {
+              "settings": "frontend/settings_ui.json"
+            }
+            """);
+        File.WriteAllText(
+            Path.Combine(settingsDirectory, AppConstants.PluginSettingsUiFileName),
+            """
+            {
+              "sections": [
+                {
+                  "title": "功能开关",
+                  "items": [
+                    {
+                      "type": "checkbox",
+                      "key": "enabled",
+                      "label": "启用"
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+        try
+        {
+            var viewModel = new PluginSettingsViewModel(
+                new FakeProfileManager(),
+                new FakeLogService(),
+                new FakePluginHost(),
+                new FakeNotificationService(),
+                "plugin.alpha",
+                "Alpha",
+                pluginDirectory,
+                configDirectory,
+                "profile-1");
+
+            var section = Assert.Single(viewModel.SettingsDefinition!.Sections!);
+            Assert.Equal("功能开关", section.Title);
+            Assert.Equal("enabled", Assert.Single(section.Items!).Key);
+        }
+        finally
+        {
+            Directory.Delete(pluginDirectory, recursive: true);
+        }
+    }
 }

--- a/AkashaNavigator/AkashaNavigator.csproj
+++ b/AkashaNavigator/AkashaNavigator.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\assets\icons\akasha-navigator.ico</ApplicationIcon>
-    <Version>1.4.0-alpha.3</Version>
+    <Version>1.4.0-alpha.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AkashaNavigator/AppConstants.cs
+++ b/AkashaNavigator/AppConstants.cs
@@ -260,6 +260,11 @@ public static class AppConstants
     public const string PluginManifestFileName = "plugin.json";
 
     /// <summary>
+    /// 未在插件清单中显式声明时使用的设置界面文件名。
+    /// </summary>
+    public const string PluginSettingsUiFileName = "settings_ui.json";
+
+    /// <summary>
     /// 插件仓库索引文件名。
     /// </summary>
     public const string PluginRepositoryIndexFileName = "repo.json";

--- a/AkashaNavigator/Helpers/PluginSettingsPathResolver.cs
+++ b/AkashaNavigator/Helpers/PluginSettingsPathResolver.cs
@@ -1,11 +1,43 @@
 using System;
 using System.IO;
+using AkashaNavigator.Models.PluginRepository;
 
 namespace AkashaNavigator.Helpers;
 
 internal static class PluginSettingsPathResolver
 {
     public static string? ResolveDirectory(string pluginDirectory, string? relativePath)
+    {
+        return ResolvePath(pluginDirectory, relativePath);
+    }
+
+    public static string? ResolveSettingsFile(string pluginDirectory, string? manifestSettingsPath)
+    {
+        if (string.IsNullOrWhiteSpace(pluginDirectory))
+        {
+            return null;
+        }
+
+        var relativePath = manifestSettingsPath;
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            var repositoryManifestResult =
+                JsonHelper.LoadFromFile<CatalogPluginManifest>(
+                    Path.Combine(
+                        pluginDirectory,
+                        AppConstants.PluginRepositoryManifestFileName));
+            relativePath = repositoryManifestResult.IsSuccess
+                ? repositoryManifestResult.Value?.Settings
+                : null;
+        }
+
+        relativePath = string.IsNullOrWhiteSpace(relativePath)
+            ? AppConstants.PluginSettingsUiFileName
+            : relativePath;
+        return ResolvePath(pluginDirectory, relativePath);
+    }
+
+    private static string? ResolvePath(string pluginDirectory, string? relativePath)
     {
         if (string.IsNullOrWhiteSpace(pluginDirectory))
         {

--- a/AkashaNavigator/Models/Plugin/PluginManifest.cs
+++ b/AkashaNavigator/Models/Plugin/PluginManifest.cs
@@ -139,6 +139,12 @@ public class PluginManifest
     public Dictionary<string, JsonElement>? DefaultConfig { get; set; }
 
     /// <summary>
+    /// 设置界面定义文件（相对于插件目录）。
+    /// 未声明时兼容读取插件根目录的 settings_ui.json。
+    /// </summary>
+    public string? Settings { get; set; }
+
+    /// <summary>
     /// ES6 模块搜索路径列表
     /// 用于 import 语句解析模块时的搜索路径
     /// 支持相对路径（相对于插件目录）和绝对路径

--- a/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
+++ b/AkashaNavigator/Models/PluginRepository/CatalogPluginManifest.cs
@@ -56,6 +56,7 @@ public sealed class CatalogPluginManifest
             Description = Description,
             Author = Authors?.FirstOrDefault()?.Name,
             MinAppVersion = Host?.MinVersion,
+            Settings = Settings,
             Permissions = Permissions?.ToList() ?? new List<string>(),
             Companion = Backend == null
                 ? null

--- a/AkashaNavigator/ViewModels/Windows/PluginSettingsViewModel.cs
+++ b/AkashaNavigator/ViewModels/Windows/PluginSettingsViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using AkashaNavigator.Core.Interfaces;
+using AkashaNavigator.Helpers;
 using AkashaNavigator.Models.Config;
 using AkashaNavigator.Models.Plugin;
 
@@ -57,13 +58,18 @@ public class PluginSettingsViewModel
 
         var manifestPath = Path.Combine(pluginDirectory, AppConstants.PluginManifestFileName);
         var manifestResult = PluginManifest.LoadFromFile(manifestPath);
-        if (manifestResult.IsSuccess && manifestResult.Manifest?.DefaultConfig != null)
+        var manifest = manifestResult.IsSuccess ? manifestResult.Manifest : null;
+        if (manifest?.DefaultConfig != null)
         {
-            Config.ApplyDefaults(manifestResult.Manifest.DefaultConfig);
+            Config.ApplyDefaults(manifest.DefaultConfig);
         }
 
-        var settingsUiPath = Path.Combine(pluginDirectory, "settings_ui.json");
-        SettingsDefinition = SettingsUiDefinition.LoadFromFile(settingsUiPath);
+        var settingsUiPath = PluginSettingsPathResolver.ResolveSettingsFile(
+            pluginDirectory,
+            manifest?.Settings);
+        SettingsDefinition = settingsUiPath == null
+            ? null
+            : SettingsUiDefinition.LoadFromFile(settingsUiPath);
     }
 
     public void UpdateValue(string key, object? value)

--- a/AkashaNavigator/Views/Windows/PluginSettingsWindow.xaml.cs
+++ b/AkashaNavigator/Views/Windows/PluginSettingsWindow.xaml.cs
@@ -242,7 +242,11 @@ public partial class PluginSettingsWindow : AnimatedWindow
         if (string.IsNullOrEmpty(pluginDirectory))
             return false;
 
-        var settingsUiPath = Path.Combine(pluginDirectory, "settings_ui.json");
-        return File.Exists(settingsUiPath);
+        var manifestResult = PluginManifest.LoadFromFile(
+            Path.Combine(pluginDirectory, AppConstants.PluginManifestFileName));
+        var settingsUiPath = PluginSettingsPathResolver.ResolveSettingsFile(
+            pluginDirectory,
+            manifestResult.IsSuccess ? manifestResult.Manifest?.Settings : null);
+        return settingsUiPath != null && File.Exists(settingsUiPath);
     }
 }

--- a/release_badges.md
+++ b/release_badges.md
@@ -1,37 +1,25 @@
-## v1.4.0-alpha.3 🎉 Release Notes
+## v1.4.0-alpha.4 🎉 Release Notes
 
-**AkashaNavigator 1.4.0-alpha.3 更新发布！** 本次 Alpha 更新完成了官方插件仓库体系迁移，并集中改善插件中心的安装、更新和状态同步体验。
+**AkashaNavigator 1.4.0-alpha.4 更新发布！** 本次 Alpha 更新修复了新版仓库插件设置界面无法加载的问题。
 
-### ✨ 插件仓库体系
+### 🛠️ 插件设置
 
-- 接入独立的 AkashaPlugins catalog，统一支持 GitHub、CNB 和自定义 Git 仓库
-- 新增插件订阅、仓库刷新和原子安装流程，更新失败时不会留下不完整安装
-- 自动保留插件声明的用户数据和配置，支持目录形式的 `savedFiles`
-- 支持 Release 分发、完整性校验以及需要独立后端进程的 companion 插件
-- 内置插件迁移到官方 catalog，移除旧版 registry、资源更新和遗留更新路径
+- 修复仓库插件安装时未将 `settings` 路径写入运行时清单的问题
+- 设置窗口现在会按插件清单声明的相对路径加载设置界面
+- 兼容已经安装的仓库插件，可从随包保留的仓库清单恢复设置路径，无需重新安装插件
+- 继续兼容设置文件位于插件根目录的旧版插件
+- 拒绝越出插件目录的设置文件路径
 
-### 🎨 插件中心
+### 🎮 原神自动化
 
-- 重做“可用插件”页面布局，使导航、工具栏、状态和卡片风格保持一致
-- 检查更新后将可更新插件自动置顶，便于快速定位
-- 修复“已安装插件”和“可用插件”使用不同 ViewModel 实例造成的状态不同步
-- 页面切换时刷新实际显示的页面，安装、订阅和更新状态保持一致
-- 支持从 ZIP 导入插件包，并集中管理仓库渠道和自动更新选项
-
-### 🛠️ 兼容性与稳定性
-
-- 修复预发布宿主被误判为低于同版本线稳定最低要求的问题
-- 统一宿主版本来源，避免插件 API 与实际应用版本不一致
-- 修复 `savedFiles` 目录标记被判定为无效路径导致插件更新失败的问题
-- 更新完成后正确保留目录内用户文件
-- 修复设置窗口关闭后旧 ViewModel 仍接收全局事件的问题
-- 补充插件安装、版本比较、页面同步和事件生命周期回归测试
+- 修复 Akasha 原神自动化 0.4.4 设置窗口显示“此插件没有可配置的设置项”
+- 升级主程序后即可恢复设置界面，无需更新或重新安装原神自动化插件
 
 ### 📥 下载
 
 | 类型 | 下载 |
 |------|------|
-| 安装版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.3/AkashaNavigator.Install.1.4.0-alpha.3.exe" title="Windows x64 安装版"><img src="https://custom-icon-badges.demolab.com/badge/.exe-0078D6?logo=windows11&logoColor=white"/></a> |
-| 便携版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.3/AkashaNavigator_v1.4.0-alpha.3.7z" title="Portable 便携版"><img src="https://custom-icon-badges.demolab.com/badge/.7z-4CAF50?logo=7zip&logoColor=white"/></a> |
+| 安装版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.4/AkashaNavigator.Install.1.4.0-alpha.4.exe" title="Windows x64 安装版"><img src="https://custom-icon-badges.demolab.com/badge/.exe-0078D6?logo=windows11&logoColor=white"/></a> |
+| 便携版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.4/AkashaNavigator_v1.4.0-alpha.4.7z" title="Portable 便携版"><img src="https://custom-icon-badges.demolab.com/badge/.7z-4CAF50?logo=7zip&logoColor=white"/></a> |
 
-> 推荐使用安装版。本版本属于 Alpha 通道；插件安装和更新前请确认权限与后端组件提示。
+> 推荐使用安装版。本版本属于 Alpha 通道。


### PR DESCRIPTION
## What changed

- preserve the repository manifest `settings` path in generated runtime plugin manifests
- load settings UI definitions from the declared plugin-relative path
- recover the path from the retained repository manifest for already-installed plugins
- keep legacy root-level `settings_ui.json` compatibility and reject traversal paths
- bump AkashaNavigator to `1.4.0-alpha.4` and update release notes

## Why

Akasha Genshin Automation 0.4.4 stores its settings definition at `frontend/settings_ui.json`. Installation retained the file but dropped the `settings` path while generating `plugin.json`, and the settings window only checked the plugin root. This caused the window to report that the plugin had no configurable settings.

## User impact

Updating AkashaNavigator restores the automation plugin settings page. Existing plugin installations do not need to be reinstalled.

## Validation

- `dotnet test AkashaNavigator.sln --no-restore`
- 1319 passed, 32 skipped, 0 failed
- `git diff --check`