### PR TITLE
release: AkashaNavigator v1.4.0

### DIFF
--- a/.agents/skills/publish-akasha-navigator/SKILL.md
+++ b/.agents/skills/publish-akasha-navigator/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: publish-akasha-navigator
+description: Interactively decide whether AkashaNavigator should be released and recommend the next version, then publish it end to end after user confirmation. Use when the user asks to 发布、发版、判断要不要升版本、下一个版本号、制作安装包、更新 Alpha/稳定版、同步 GitHub/CNB，或修复“检查更新检测不到新版本”。 Covers change analysis, semantic versioning, release notes, validation, PR merge, GitHub Actions packaging, GitHub Release publication, Qiniu notice.json update, CDN verification, and updater visibility.
+---
+
+# Publish AkashaNavigator
+
+Treat a release as incomplete until both the binaries and the online update
+manifest are published.
+
+## Make the version decision interactively
+
+Always complete this section before editing a version, release notes, tags, or
+external release state.
+
+1. Work from the repository root.
+2. Read:
+   - `AkashaNavigator/AkashaNavigator.csproj`
+   - `release_badges.md`
+   - `.github/workflows/publish.yml`
+   - `.github/workflows/update_notice.yml`
+3. Run `gh auth status` and confirm the repository is
+   `ColinXHL/akasha-navigator`.
+4. Fetch `origin` and tags, then collect the decision context:
+
+```powershell
+& .agents/skills/publish-akasha-navigator/scripts/get-version-context.ps1
+```
+
+5. Inspect:
+   - the project version
+   - the latest published Release and tag
+   - the online stable and Alpha manifest versions
+   - commits and diff since the latest published tag
+   - staged, unstaged, and untracked work
+6. Decide whether a release is warranted:
+   - Recommend **no release yet** for incomplete work, internal-only
+     experiments, or changes with no user-facing/package impact.
+   - Recommend a release for user-visible fixes or features, security and data
+     integrity changes, packaging/updater changes, or fixes users are waiting
+     for.
+   - Any new public release must have a unique version. If the project version
+     is already published, it must change.
+   - If the project already contains an unpublished version that matches the
+     change scope, keep it instead of incrementing again.
+7. Recommend the version:
+
+| Current release state | Change scope | Recommendation |
+|---|---|---|
+| Alpha train | ordinary fixes or compatible features | increment `alpha.N` |
+| Alpha train | next planned feature line | start the next minor Alpha |
+| Stable | backward-compatible bug fix | patch |
+| Stable | backward-compatible feature | minor |
+| Stable | breaking behavior/API/data change | major |
+| Alpha is ready for general use | stabilization only | promote the same core version to stable |
+
+Do not treat commit prefixes mechanically. Explain the user and compatibility
+impact that drives the recommendation.
+
+8. Present a short decision prompt in this shape:
+
+```text
+当前已发布：v<X>
+本次改动：<one-line summary>
+
+建议：<不发布 / v<Y>>（推荐）
+理由：
+- <reason>
+- <reason>
+
+备选：
+1. <alternative and tradeoff>
+2. <alternative and tradeoff>
+
+你确认采用哪个方案？
+```
+
+Offer at most three mutually exclusive choices, put the recommendation first,
+and stop for explicit user confirmation. Do not edit the version, release
+notes, tags, PR state, or workflows while waiting.
+
+If the user already supplied an exact version and explicitly requested its
+publication, treat that as confirmation after checking that it is valid,
+unused, and compatible with the changes. Surface conflicts instead of silently
+choosing another version.
+
+9. Preserve unrelated working-tree changes. Never use `git add -A` in a
+   mixed worktree.
+10. Never reuse or overwrite an existing tag or Release.
+
+## Prepare the source
+
+Start only after the user confirms the release decision and exact version.
+
+1. Create a `codex/` release or fix branch before committing.
+2. Implement the requested changes and add focused regression tests.
+3. Update `<Version>` in `AkashaNavigator/AkashaNavigator.csproj`.
+4. Replace `release_badges.md` with notes for exactly `## v<VERSION>`.
+   Include correct installer and portable download links.
+5. Run:
+
+```powershell
+& .agents/skills/publish-akasha-navigator/scripts/test-release-readiness.ps1 `
+  -Version <VERSION>
+```
+
+6. Require `dotnet test AkashaNavigator.sln --no-restore` and
+   `git diff --check` to pass. Existing skipped tests are acceptable; new
+   failures are not.
+
+## Land the release commit
+
+1. Inspect the final diff and stage only intended paths.
+2. Commit with a concise conventional message.
+3. Push the `codex/` branch to `origin`.
+4. Open a PR against `main`, with:
+   - root cause and user impact
+   - exact validation results
+   - version being published
+5. For an explicit user request to publish, mark the PR ready and merge it
+   after required checks pass. Prefer squash merge.
+6. Fetch and fast-forward local `main`. Confirm the version commit is at
+   `origin/main`.
+
+Do not run the release workflow from an unmerged feature branch.
+
+## Build and publish the binaries
+
+Map channels as follows:
+
+| Version | `publish.yml` channel | Release kind |
+|---|---|---|
+| contains a prerelease suffix | `dev` | prerelease |
+| stable semantic version | `release` | stable |
+
+Trigger:
+
+```powershell
+gh workflow run publish.yml --ref main `
+  -f version=<VERSION> `
+  -f channel=<dev-or-release> `
+  -f create_release=true `
+  -f push_to_cnb=true
+```
+
+Capture the run URL/ID and monitor it until terminal. Require all applicable
+jobs to succeed:
+
+- `validate`
+- `build_dist`
+- `build_installer`
+- `Trigger CNB Build`
+- `Create GitHub Release`
+
+If a job fails, inspect its logs and stop. Do not publish partial artifacts.
+
+The workflow creates a draft GitHub Release. Verify both assets exist:
+
+- `AkashaNavigator.Install.<VERSION>.exe`
+- `AkashaNavigator_v<VERSION>.7z`
+
+Then publish the draft:
+
+```powershell
+# Prerelease
+gh release edit v<VERSION> --draft=false --prerelease
+
+# Stable
+gh release edit v<VERSION> --draft=false --latest
+```
+
+Re-read the Release and confirm it is no longer a draft. The CNB job confirms
+that synchronization was triggered; do not claim the downstream CNB release
+completed unless it was independently verified.
+
+## Publish the updater manifest
+
+This step is mandatory and separate from `publish.yml`. Omitting it makes the
+application report that the old version is still current.
+
+1. Read the current online manifest:
+
+```powershell
+Invoke-RestMethod 'https://update.fisheepx.cn/notice.json'
+```
+
+2. Preserve its `min_required_version` unless the user explicitly requests a
+   forced-upgrade policy change.
+3. Use channel `alpha` for prereleases and `stable` for stable versions.
+4. Keep source `qiniu` unless the repository configuration changed.
+5. Trigger:
+
+```powershell
+gh workflow run update_notice.yml --ref main `
+  -f version=<VERSION> `
+  -f channel=<alpha-or-stable> `
+  -f min_required_version=<CURRENT_MINIMUM> `
+  -f notes='<CONCISE_USER_FACING_NOTES>' `
+  -f source=qiniu
+```
+
+6. Monitor the run and require these jobs to succeed:
+   - `validate`
+   - `build_notice`
+   - `upload_notice`
+7. Verify both a cache-busting request and the normal URL return the new
+   channel version:
+
+```powershell
+$bust = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+Invoke-RestMethod "https://update.fisheepx.cn/notice.json?ts=$bust"
+Invoke-RestMethod 'https://update.fisheepx.cn/notice.json'
+```
+
+Do not report the release complete before this verification passes.
+
+## Final report
+
+Provide:
+
+- released version and whether it is prerelease/stable
+- GitHub Release, PR, binary workflow, and notice workflow links
+- installer and portable download links
+- test totals
+- updater-manifest version observed online
+- precise CNB status: completed only if verified, otherwise triggered
+
+If the client still cannot detect the release, inspect:
+
+- installed executable `ProductVersion`
+- `enablePrereleaseUpdate` in `User/Data/config.json`
+- `User/Data/Update/notice-cache.json`
+- `User/Data/Update/notice-state.json`
+- the latest application log

--- a/.agents/skills/publish-akasha-navigator/agents/openai.yaml
+++ b/.agents/skills/publish-akasha-navigator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "交互发布 AkashaNavigator"
+  short_description: "交互判断下一个版本号，再完整发布并验证更新清单与 CDN"
+  default_prompt: "Use $publish-akasha-navigator to analyze the changes, recommend whether and how to bump the version, and wait for my confirmation before publishing."

--- a/.agents/skills/publish-akasha-navigator/scripts/get-version-context.ps1
+++ b/.agents/skills/publish-akasha-navigator/scripts/get-version-context.ps1
@@ -1,0 +1,107 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+$originalLocation = Get-Location
+
+try {
+    Set-Location $projectRoot
+
+    $projectFile = 'AkashaNavigator\AkashaNavigator.csproj'
+    $projectText = Get-Content -Raw -LiteralPath $projectFile
+    $versionMatch = [regex]::Match(
+        $projectText,
+        '<Version>(?<version>[^<]+)</Version>')
+    if (-not $versionMatch.Success) {
+        throw "Could not read <Version> from $projectFile"
+    }
+
+    & gh auth status | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub CLI is not authenticated'
+    }
+
+    $repository = (& gh repo view --json nameWithOwner --jq '.nameWithOwner').Trim()
+    if ($LASTEXITCODE -ne 0 -or $repository -ne 'ColinXHL/akasha-navigator') {
+        throw "Unexpected GitHub repository: $repository"
+    }
+
+    $releaseJson = & gh release list `
+        --exclude-drafts `
+        --limit 1 `
+        --json tagName,name,isPrerelease,publishedAt
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not read the latest GitHub Release'
+    }
+
+    $latestRelease = @($releaseJson | ConvertFrom-Json) |
+        Select-Object -First 1
+    $baseTag = $latestRelease.tagName
+
+    $commits = @()
+    $committedDiff = ''
+    if (-not [string]::IsNullOrWhiteSpace($baseTag)) {
+        $commits = @(
+            & git log "$baseTag..HEAD" --pretty=format:'%h%x09%s'
+        )
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect commits since $baseTag"
+        }
+
+        $committedDiff = @(
+            & git diff --stat "$baseTag..HEAD"
+        ) -join "`n"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect diff since $baseTag"
+        }
+    }
+
+    $workingTreeStatus = @(& git status --short)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not inspect the working tree'
+    }
+
+    $unstagedDiff = @(& git diff --stat) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not inspect unstaged changes'
+    }
+
+    $stagedDiff = @(& git diff --cached --stat) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not inspect staged changes'
+    }
+
+    $notice = Invoke-RestMethod `
+        -Uri 'https://update.fisheepx.cn/notice.json'
+
+    [ordered]@{
+        repository = $repository
+        projectVersion = $versionMatch.Groups['version'].Value
+        latestRelease = if ($null -eq $latestRelease) {
+            $null
+        }
+        else {
+            [ordered]@{
+                tag = $latestRelease.tagName
+                name = $latestRelease.name
+                isPrerelease = $latestRelease.isPrerelease
+                publishedAt = $latestRelease.publishedAt
+            }
+        }
+        onlineManifest = [ordered]@{
+            stable = $notice.stable.version
+            alpha = $notice.alpha.version
+            minRequiredVersion = $notice.min_required_version
+        }
+        commitsSinceLatestRelease = $commits
+        committedDiffSinceLatestRelease = $committedDiff
+        workingTreeStatus = $workingTreeStatus
+        stagedDiff = $stagedDiff
+        unstagedDiff = $unstagedDiff
+    } | ConvertTo-Json -Depth 6
+}
+finally {
+    Set-Location $originalLocation
+}

--- a/.agents/skills/publish-akasha-navigator/scripts/test-release-readiness.ps1
+++ b/.agents/skills/publish-akasha-navigator/scripts/test-release-readiness.ps1
@@ -1,0 +1,99 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$')]
+    [string]$Version,
+
+    [switch]$SkipTests,
+
+    [switch]$AllowPublishedVersion
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+$originalLocation = Get-Location
+
+try {
+    Set-Location $projectRoot
+
+    $projectFile = 'AkashaNavigator\AkashaNavigator.csproj'
+    $releaseNotesFile = 'release_badges.md'
+
+    if (-not (Test-Path -LiteralPath $projectFile)) {
+        throw "Project file not found: $projectFile"
+    }
+
+    if (-not (Test-Path -LiteralPath $releaseNotesFile)) {
+        throw "Release notes not found: $releaseNotesFile"
+    }
+
+    $projectText = Get-Content -Raw -LiteralPath $projectFile
+    $versionMatch = [regex]::Match(
+        $projectText,
+        '<Version>(?<version>[^<]+)</Version>')
+    if (-not $versionMatch.Success) {
+        throw "Could not read <Version> from $projectFile"
+    }
+
+    $projectVersion = $versionMatch.Groups['version'].Value
+    if ($projectVersion -ne $Version) {
+        throw "Requested version $Version does not match project version $projectVersion"
+    }
+
+    $releaseNotes = Get-Content -Raw -LiteralPath $releaseNotesFile
+    if (-not $releaseNotes.Contains("## v$Version")) {
+        throw "$releaseNotesFile does not contain a ## v$Version heading"
+    }
+
+    & gh --version | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub CLI is unavailable'
+    }
+
+    & gh auth status | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub CLI is not authenticated'
+    }
+
+    $repository = (& gh repo view --json nameWithOwner --jq '.nameWithOwner').Trim()
+    if ($LASTEXITCODE -ne 0 -or $repository -ne 'ColinXHL/akasha-navigator') {
+        throw "Unexpected GitHub repository: $repository"
+    }
+
+    & git diff --check
+    if ($LASTEXITCODE -ne 0) {
+        throw 'git diff --check failed'
+    }
+
+    $remoteTag = & git ls-remote --tags origin "refs/tags/v$Version"
+    if (-not $AllowPublishedVersion -and -not [string]::IsNullOrWhiteSpace($remoteTag)) {
+        throw "Tag v$Version already exists on origin"
+    }
+
+    & gh release view "v$Version" --json tagName 2>$null | Out-Null
+    $releaseExists = $LASTEXITCODE -eq 0
+    if (-not $AllowPublishedVersion -and $releaseExists) {
+        throw "GitHub Release v$Version already exists"
+    }
+
+    if (-not $SkipTests) {
+        & dotnet test AkashaNavigator.sln --no-restore
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Test suite failed'
+        }
+    }
+
+    [PSCustomObject]@{
+        Repository = $repository
+        Version = $Version
+        ProjectVersion = $projectVersion
+        ReleaseNotesHeading = "## v$Version"
+        TestsRun = -not $SkipTests
+        ExistingReleaseAllowed = [bool]$AllowPublishedVersion
+        Ready = $true
+    } | Format-List
+}
+finally {
+    Set-Location $originalLocation
+}

--- a/AkashaNavigator.Tests/HoldToPeekTests.cs
+++ b/AkashaNavigator.Tests/HoldToPeekTests.cs
@@ -14,10 +14,10 @@ namespace AkashaNavigator.Tests
         #region Config Defaults
 
         [Fact]
-        public void AppConfig_Default_EnableHoldToPeek_IsTrue()
+        public void AppConfig_Default_EnableHoldToPeek_IsFalse()
         {
             var config = new AppConfig();
-            Assert.True(config.EnableHoldToPeek);
+            Assert.False(config.EnableHoldToPeek);
         }
 
         [Fact]
@@ -184,13 +184,13 @@ namespace AkashaNavigator.Tests
         public void WindowSettingsPageVM_SaveSettings_SavesPeekProperties()
         {
             var vm = new WindowSettingsPageViewModel();
-            vm.EnableHoldToPeek = false;
+            vm.EnableHoldToPeek = true;
             vm.PeekOpacityPercent = 80.0;
 
             var config = new AppConfig();
             vm.SaveSettings(config);
 
-            Assert.False(config.EnableHoldToPeek);
+            Assert.True(config.EnableHoldToPeek);
             Assert.Equal(0.8, config.PeekOpacity, 2); // 80% → 0.8
         }
 
@@ -213,13 +213,13 @@ namespace AkashaNavigator.Tests
         public void WindowSettingsPageVM_ResetSettings_RestoresPeekDefaults()
         {
             var vm = new WindowSettingsPageViewModel();
-            vm.EnableHoldToPeek = false;
+            vm.EnableHoldToPeek = true;
             vm.PeekOpacityPercent = 50.0;
 
             var defaultConfig = new AppConfig();
             vm.ResetSettings(defaultConfig);
 
-            Assert.True(vm.EnableHoldToPeek);
+            Assert.False(vm.EnableHoldToPeek);
             Assert.Equal(AppConstants.DefaultPeekOpacity * 100.0, vm.PeekOpacityPercent, 1);
         }
 

--- a/AkashaNavigator.Tests/Plugins/PluginHostObjectFactoryTests.cs
+++ b/AkashaNavigator.Tests/Plugins/PluginHostObjectFactoryTests.cs
@@ -4,12 +4,14 @@ using System.IO;
 using AkashaNavigator.Core;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Helpers;
+using AkashaNavigator.Models.Data;
 using AkashaNavigator.Models.Plugin;
 using AkashaNavigator.Plugins.Core;
 using AkashaNavigator.Plugins.Utils;
 using AkashaNavigator.Services;
 using AkashaNavigator.Tests.TestDoubles;
 using Microsoft.ClearScript.V8;
+using Moq;
 using Xunit;
 
 namespace AkashaNavigator.Tests.Plugins;
@@ -142,6 +144,47 @@ public class PluginHostObjectFactoryTests
                                       new PluginEngineOptions());
 
         Assert.False(IsGlobalDefined(engine, "osd"));
+    }
+
+    [Fact]
+    public void PluginContextDispose_DetachesGlobalSubtitleApiBeforeDisposingEngine()
+    {
+        using var tempDir = new TempDirectory();
+        var subtitleService = new Mock<ISubtitleService>();
+        var factory = new PluginHostObjectFactory(new TestPlayerRuntimeBridge(),
+                                                  new OverlayManager(),
+                                                  new PanelManager(),
+                                                  new TestCursorDetectionService(),
+                                                  subtitleService.Object,
+                                                  new ScriptExecutionQueue(new FakeLogService()),
+                                                  new HotkeyService(),
+                                                  new OsdManager(),
+                                                  new FakeLogService(),
+                                                  new CompanionProcessManager(new FakeLogService()));
+        var options = new PluginEngineOptions { HostObjectFactory = factory };
+        var manifest = CreateManifest(PluginPermissions.Subtitle);
+        var context = PluginContext.Create(manifest,
+                                           tempDir.Path,
+                                           tempDir.Path,
+                                           new PluginConfig(manifest.Id!),
+                                           options);
+
+        subtitleService.VerifyAdd(
+            service => service.SubtitleLoaded += It.IsAny<EventHandler<SubtitleData>>(),
+            Times.Once);
+
+        context.Dispose();
+        context.Dispose();
+
+        subtitleService.VerifyRemove(
+            service => service.SubtitleLoaded -= It.IsAny<EventHandler<SubtitleData>>(),
+            Times.Once);
+        subtitleService.VerifyRemove(
+            service => service.SubtitleChanged -= It.IsAny<EventHandler<SubtitleEntry?>>(),
+            Times.Once);
+        subtitleService.VerifyRemove(
+            service => service.SubtitleCleared -= It.IsAny<EventHandler>(),
+            Times.Once);
     }
 
     private static V8ScriptEngine CreateEngineForTest()

--- a/AkashaNavigator.Tests/Services/AppUpdateServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/AppUpdateServiceTests.cs
@@ -52,4 +52,33 @@ public sealed class AppUpdateServiceTests
         Assert.True(result.IsFailure);
         Assert.Same(expectedError, result.Error);
     }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_StableWinsOverSameCorePrerelease()
+    {
+        var manifest = new UpdateManifest {
+            Stable = new AppUpdateChannelInfo {
+                Version = "999.0.0",
+                Notes = "stable release"
+            },
+            Alpha = new AppUpdateChannelInfo {
+                Version = "999.0.0-alpha.4",
+                Notes = "alpha release"
+            }
+        };
+        var manifestService = new Mock<IUpdateManifestService>();
+        manifestService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<UpdateManifest>.Success(manifest));
+        var service = new AppUpdateService(new Mock<ILogService>().Object, manifestService.Object);
+
+        var result = await service.CheckForUpdateAsync(includePrerelease: true);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value?.HasUpdate);
+        Assert.Equal("999.0.0", result.Value?.TargetVersion);
+        Assert.Equal("stable release", result.Value?.Notes);
+        Assert.False(result.Value?.IsPrerelease);
+        Assert.Equal("cnb", result.Value?.SourceId);
+    }
 }

--- a/AkashaNavigator.Tests/Services/DataServiceTests.cs
+++ b/AkashaNavigator.Tests/Services/DataServiceTests.cs
@@ -622,8 +622,8 @@ public class DataServiceTests : IDisposable
     public async Task MixedOperations_ConcurrentCalls_KnownConcurrencyIssues()
     {
         // Arrange
-        _dataService.AddBookmark("url1", "Title 1");
-        _dataService.AddBookmark("url2", "Title 2");
+        _dataService.AddHistory("url1", "Title 1");
+        _dataService.AddHistory("url2", "Title 2");
         var tasks = new Task[50];
         var random = new Random();
 

--- a/AkashaNavigator/AkashaNavigator.csproj
+++ b/AkashaNavigator/AkashaNavigator.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\assets\icons\akasha-navigator.ico</ApplicationIcon>
-    <Version>1.4.0-alpha.4</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AkashaNavigator/Helpers/WindowBehaviorHelper.cs
+++ b/AkashaNavigator/Helpers/WindowBehaviorHelper.cs
@@ -42,7 +42,7 @@ public class WindowBehaviorHelper
     private bool _isPeekHeld;
     private bool _isPeekActive; // 当前是否实际处于窥视透明度
     private double _peekOpacity = AppConstants.DefaultPeekOpacity;
-    private bool _enablePeek = true;
+    private bool _enablePeek;
 
 #endregion
 

--- a/AkashaNavigator/Models/Config/AppConfig.cs
+++ b/AkashaNavigator/Models/Config/AppConfig.cs
@@ -83,9 +83,9 @@ public class AppConfig
     public bool EnableHotkeysWhenHidden { get; set; } = false;
 
     /// <summary>
-    /// 是否启用按住窥视功能（默认 true）
+    /// 是否启用按住窥视功能（默认关闭）
     /// </summary>
-    public bool EnableHoldToPeek { get; set; } = true;
+    public bool EnableHoldToPeek { get; set; } = false;
 
     /// <summary>
     /// 窥视时的透明度（默认 0.2，范围 MinOpacity - MaxOpacity）

--- a/AkashaNavigator/Plugins/Apis/HotkeyApi.cs
+++ b/AkashaNavigator/Plugins/Apis/HotkeyApi.cs
@@ -51,12 +51,7 @@ public class HotkeyApi
     /// </summary>
     internal void Cleanup()
     {
-        foreach (var registration in _registrations.Values)
-        {
-            _dispatcher.UnregisterAction(registration.ActionName);
-        }
-        _registrations.Clear();
-        _keyComboToId.Clear();
+        UnregisterAll();
     }
 
 #endregion

--- a/AkashaNavigator/Plugins/Core/PluginContext.cs
+++ b/AkashaNavigator/Plugins/Core/PluginContext.cs
@@ -118,7 +118,7 @@ public class PluginContext : IDisposable
         PluginDirectory = pluginDirectory ?? throw new ArgumentNullException(nameof(pluginDirectory));
         ConfigDirectory = pluginDirectory;
         _config = config;
-        _engineOptions = options;
+        _engineOptions = options ?? new PluginEngineOptions();
 
         InitializeWithPluginEngine();
     }
@@ -545,6 +545,10 @@ public class PluginContext : IDisposable
             {
                 CallOnUnload();
             }
+
+            // 先取消宿主对象对全局服务的订阅，再释放 V8 引擎，
+            // 避免旧回调在插件卸载/重载后访问已销毁的脚本引擎。
+            _engineOptions?.CleanupHostObjects();
 
             // V8 引擎需要显式释放
             _jsEngine?.Dispose();

--- a/AkashaNavigator/Plugins/Core/PluginEngine.cs
+++ b/AkashaNavigator/Plugins/Core/PluginEngine.cs
@@ -326,6 +326,7 @@ public static class PluginEngine
             }
 
             engine.AddHostObject("window", windowApi);
+            options.RegisterHostObjectCleanup(windowApi.Cleanup);
             LogService.Instance.Debug($"PluginEngine:{pluginId}", "Exposed: window");
         }
 
@@ -358,6 +359,7 @@ public static class PluginEngine
         {
             var httpApi = new HttpApi(pluginId, manifest.HttpAllowedUrls?.ToArray());
             engine.AddHostObject("http", httpApi);
+            options.RegisterHostObjectCleanup(httpApi.Dispose);
             LogService.Instance.Debug($"PluginEngine:{pluginId}", "Exposed: http");
         }
 
@@ -377,6 +379,7 @@ public static class PluginEngine
             }
 
             engine.AddHostObject("subtitle", subtitleApi);
+            options.RegisterHostObjectCleanup(subtitleApi.Cleanup);
             LogService.Instance.Debug($"PluginEngine:{pluginId}", "Exposed: subtitle");
         }
 
@@ -398,6 +401,7 @@ public static class PluginEngine
                     RequireLegacyOption(options.HotkeyService, nameof(PluginEngineOptions.HotkeyService),
                                         nameof(HotkeyApi)).GetDispatcher());
             engine.AddHostObject("hotkey", hotkeyApi);
+            options.RegisterHostObjectCleanup(hotkeyApi.Cleanup);
             LogService.Instance.Debug($"PluginEngine:{pluginId}", "Exposed: hotkey");
         }
 

--- a/AkashaNavigator/Plugins/Core/PluginEngineOptions.cs
+++ b/AkashaNavigator/Plugins/Core/PluginEngineOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using AkashaNavigator.Core.Interfaces;
 using AkashaNavigator.Helpers;
 using AkashaNavigator.Models.Config;
@@ -11,6 +12,9 @@ namespace AkashaNavigator.Plugins.Core
 /// </summary>
 public class PluginEngineOptions
 {
+    private readonly List<Action> _hostObjectCleanupActions = new();
+    private bool _hostObjectsCleanedUp;
+
     /// <summary>
     /// 当前 Profile ID
     /// </summary>
@@ -65,5 +69,50 @@ public class PluginEngineOptions
     /// </summary>
     [Obsolete("Legacy fallback mode only. Prefer HostObjectFactory.", false)]
     public AkashaNavigator.Core.OsdManager? OsdManager { get; set; }
+
+    /// <summary>
+    /// 注册由插件引擎创建、需要在 V8 引擎销毁前释放的宿主对象。
+    /// </summary>
+    internal void RegisterHostObjectCleanup(Action cleanup)
+    {
+        ArgumentNullException.ThrowIfNull(cleanup);
+
+        if (_hostObjectsCleanedUp)
+        {
+            throw new ObjectDisposedException(nameof(PluginEngineOptions));
+        }
+
+        _hostObjectCleanupActions.Add(cleanup);
+    }
+
+    /// <summary>
+    /// 以创建顺序的逆序释放宿主对象。该方法是幂等的。
+    /// </summary>
+    internal void CleanupHostObjects()
+    {
+        if (_hostObjectsCleanedUp)
+        {
+            return;
+        }
+
+        _hostObjectsCleanedUp = true;
+
+        for (var i = _hostObjectCleanupActions.Count - 1; i >= 0; i--)
+        {
+            try
+            {
+                _hostObjectCleanupActions[i]();
+            }
+            catch (Exception ex)
+            {
+                (LogService ?? Services.LogService.Instance).Error(
+                    nameof(PluginEngineOptions),
+                    ex,
+                    "清理插件宿主对象失败");
+            }
+        }
+
+        _hostObjectCleanupActions.Clear();
+    }
 }
 }

--- a/release_badges.md
+++ b/release_badges.md
@@ -1,25 +1,36 @@
-## v1.4.0-alpha.4 🎉 Release Notes
+## v1.4.0 🎉 Release Notes
 
-**AkashaNavigator 1.4.0-alpha.4 更新发布！** 本次 Alpha 更新修复了新版仓库插件设置界面无法加载的问题。
+**AkashaNavigator 1.4.0 正式版发布！** 本次版本完成了应用更新、插件仓库和自动化插件分发体系升级，并集中改善插件安装、设置、更新与运行稳定性。
 
-### 🛠️ 插件设置
+### ✨ 插件仓库与在线更新
 
-- 修复仓库插件安装时未将 `settings` 路径写入运行时清单的问题
-- 设置窗口现在会按插件清单声明的相对路径加载设置界面
-- 兼容已经安装的仓库插件，可从随包保留的仓库清单恢复设置路径，无需重新安装插件
-- 继续兼容设置文件位于插件根目录的旧版插件
-- 拒绝越出插件目录的设置文件路径
+- 接入独立插件 Catalog，支持 GitHub、CNB 和自定义 Git 仓库
+- “可用插件”页面支持直接安装、更新、订阅以及从 ZIP 导入插件
+- 应用与插件下载支持多源测速、自动选择和失败回退
+- 插件包安装前校验版本、文件大小和 SHA-256，更新失败时自动回滚
+- 支持 Release 分发、用户文件保留以及需要独立后端进程的 Companion 插件
 
-### 🎮 原神自动化
+### 🎮 原神自动化与插件设置
 
-- 修复 Akasha 原神自动化 0.4.4 设置窗口显示“此插件没有可配置的设置项”
-- 升级主程序后即可恢复设置界面，无需更新或重新安装原神自动化插件
+- 原神 Profile 默认推荐 Akasha 原神自动化插件
+- 支持分别配置自动拾取和自动剧情快捷键，并显示 OSD 状态提示
+- 修复原神自动化设置窗口显示“此插件没有可配置的设置项”的问题
+- 兼容已安装插件，可从仓库清单恢复设置路径，无需重新安装
+- “按住窥视”功能改为默认关闭，可在窗口设置中按需启用
+
+### 🛡️ 稳定性与安全
+
+- 插件更新采用原子替换并保留用户配置，避免不完整安装
+- 增加高风险权限确认、插件路径校验和 Companion 进程生命周期管理
+- 修复插件热重载后旧字幕 API 仍访问已释放 V8 引擎的问题
+- 插件卸载时统一清理字幕、窗口事件、热键和网络资源
+- 修复预发布宿主版本比较、插件中心状态同步及设置窗口事件残留问题
 
 ### 📥 下载
 
 | 类型 | 下载 |
 |------|------|
-| 安装版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.4/AkashaNavigator.Install.1.4.0-alpha.4.exe" title="Windows x64 安装版"><img src="https://custom-icon-badges.demolab.com/badge/.exe-0078D6?logo=windows11&logoColor=white"/></a> |
-| 便携版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0-alpha.4/AkashaNavigator_v1.4.0-alpha.4.7z" title="Portable 便携版"><img src="https://custom-icon-badges.demolab.com/badge/.7z-4CAF50?logo=7zip&logoColor=white"/></a> |
+| 安装版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0/AkashaNavigator.Install.1.4.0.exe" title="Windows x64 安装版"><img src="https://custom-icon-badges.demolab.com/badge/.exe-0078D6?logo=windows11&logoColor=white"/></a> |
+| 便携版 | <a href="https://github.com/ColinXHL/akasha-navigator/releases/download/v1.4.0/AkashaNavigator_v1.4.0.7z" title="Portable 便携版"><img src="https://custom-icon-badges.demolab.com/badge/.7z-4CAF50?logo=7zip&logoColor=white"/></a> |
 
-> 推荐使用安装版。本版本属于 Alpha 通道。
+> 推荐使用安装版。首次启用自动化插件时请确认权限提示，并熟悉插件提供的紧急停止热键。


### PR DESCRIPTION
## 发布目标

发布 AkashaNavigator v1.4.0 稳定版。

## 主要改动

- 将按住窥视功能改为默认关闭，同时保留现有用户已保存的选择
- 修复插件热重载后全局宿主 API 未清理，导致旧字幕回调访问已释放 V8 引擎的问题
- 统一清理插件字幕、窗口事件、热键和 HTTP 资源
- 增加 Alpha 到同核心稳定版的更新选择回归测试
- 修正并发测试前置数据导致的随机失败
- 新增项目内交互式发布 Skill
- 更新版本号和 v1.4.0 正式版发布说明

## 根因与用户影响

PluginEngine 创建的全局 SubtitleApi 独立订阅 SubtitleService，但原卸载流程只清理 PluginApi 内的另一套对象。插件重载后旧实例仍会收到字幕事件，并尝试访问已释放的 V8ScriptEngine。修复后，PluginContext 会在销毁 V8 前逆序清理所有需要释放的全局宿主对象。

## 验证

- 发布就绪脚本：Ready = True
- 完整测试：1321 passed, 32 skipped, 0 failed
- V8 订阅生命周期回归测试：通过
- 同核心 Alpha → Stable 更新选择回归测试：通过
- 并发压力测试连续 5 次：通过
- Release publish：通过
- git diff --check：通过